### PR TITLE
fix: 리프레시 500 에러 시 쿠키 삭제 안되던 현상 수정

### DIFF
--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+function getSafeRedirectPath(request: NextRequest): string {
+  const redirectTo = request.nextUrl.searchParams.get('redirectTo') ?? '/signin'
+
+  if (!redirectTo.startsWith('/') || redirectTo.startsWith('//')) {
+    return '/signin'
+  }
+
+  return redirectTo
+}
+
+export async function GET(request: NextRequest) {
+  const redirectUrl = new URL(getSafeRedirectPath(request), request.url)
+  const response = NextResponse.redirect(redirectUrl)
+  response.cookies.delete('accessToken')
+  response.cookies.delete('refreshToken')
+  return response
+}
+
+export async function POST() {
+  const response = NextResponse.json({ success: true })
+  response.cookies.delete('accessToken')
+  response.cookies.delete('refreshToken')
+  return response
+}

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,36 +1,44 @@
 import { cookies } from 'next/headers'
 import { NextResponse } from 'next/server'
 import { parseSetCookieExpires } from '@/shared/lib/utils/cookie'
+import type { ApiResponse } from '@/shared/lib/api/types'
 
-/**
- * POST /api/auth/refresh
- * 클라이언트에서 401을 받았을 때 호출되는 토큰 갱신 Route Handler.
- * httpOnly 쿠키는 JS에서 직접 읽을 수 없으므로 서버를 경유해 refresh 처리.
- *
- * TODO: 백엔드 refresh 엔드포인트 확정 후 아래 주석 해제 및 구현
- */
+type TokenData = {
+  accessToken?: string
+  refreshToken?: string
+}
+
+function refreshFailure(status: number, data?: Partial<ApiResponse<TokenData>>) {
+  const response = NextResponse.json(
+    { success: false, code: data?.code, message: data?.message },
+    { status },
+  )
+  response.cookies.delete('accessToken')
+  response.cookies.delete('refreshToken')
+  return response
+}
+
 export async function POST() {
   try {
     const cookieStore = await cookies()
 
     const refreshToken = cookieStore.get('refreshToken')?.value
     if (!refreshToken) {
-      return NextResponse.json({ success: false }, { status: 401 })
+      return refreshFailure(401)
     }
 
     const apiUrl = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, '')
+
     const res = await fetch(`${apiUrl}/api/v1/auth/reissue`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ refreshToken }),
     })
 
-    const data = await res.json()
+    const data = (await res.json().catch(() => ({}))) as Partial<ApiResponse<TokenData>>
+
     if (!data.success || !data.data?.accessToken) {
-      return NextResponse.json(
-        { success: false, code: data.code, message: data.message },
-        { status: res.status },
-      )
+      return refreshFailure(res.status || 401, data)
     }
 
     const response = NextResponse.json({ success: true, accessToken: data.data.accessToken })
@@ -57,6 +65,6 @@ export async function POST() {
 
     return response
   } catch {
-    return NextResponse.json({ success: false }, { status: 500 })
+    return refreshFailure(500)
   }
 }

--- a/src/shared/lib/api/clientApi.ts
+++ b/src/shared/lib/api/clientApi.ts
@@ -57,7 +57,8 @@ async function attemptRefresh(): Promise<string | null> {
 
 function redirectToSignin() {
   if (typeof window !== 'undefined') {
-    window.location.replace('/signin')
+    useAuthStore.getState().logout()
+    window.location.replace('/api/auth/logout?redirectTo=/signin')
   }
 }
 

--- a/src/shared/lib/api/serverApi.ts
+++ b/src/shared/lib/api/serverApi.ts
@@ -24,7 +24,6 @@ async function tryRefresh(
   cookieStore: Awaited<ReturnType<typeof cookies>>,
 ): Promise<string | null> {
   const refreshToken = cookieStore.get('refreshToken')?.value
-  console.log(`[tryRefresh] refreshToken 존재: ${!!refreshToken}`)
   if (!refreshToken) return null
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, '')
@@ -36,7 +35,6 @@ async function tryRefresh(
     })
 
     const data = await res.json()
-    console.log(`[tryRefresh] status: ${res.status}, body:`, JSON.stringify(data, null, 2))
     if (!data.success || !data.data?.accessToken) return null
 
     const newAccessToken: string = data.data.accessToken
@@ -88,7 +86,6 @@ async function tryRefresh(
  * 에러 발생 시 throw — 호출 측에서 try/catch 사용.
  */
 
-
 // 현재 프로젝트의 serverApi.ts 코드를 자세히 보면, serverFetch 함수가 결과를 반환할 때 이미 Promise<ApiResponse<T>> 형태로 감싸서 주고 있습니다.
 // 즉, serverApi.get을 호출할 때는 실제 핵심 데이터(Notice[])만 제네릭(<>)으로 넘겨주면, serverApi 내부에서 알아서 ApiResponse 껍데기를 씌워서 반환해 줍니다.
 
@@ -127,9 +124,6 @@ async function serverFetch<T>(
     throw new NetworkError()
   }
 
-  const resText = await res.clone().text()
-  console.log(`[serverApi] ${method} ${url} → ${res.status}\n`, resText)
-
   if (res.status === 401) {
     const newAccessToken = await tryRefresh(cookieStore)
     if (!newAccessToken) {
@@ -139,7 +133,7 @@ async function serverFetch<T>(
       } catch {
         // RSC 컨텍스트에서는 쿠키 삭제 불가 — proxy 루프 방지 불가
       }
-      redirect('/signin')
+      redirect('/api/auth/logout?redirectTo=/signin')
     }
 
     try {
@@ -147,8 +141,6 @@ async function serverFetch<T>(
     } catch {
       throw new NetworkError()
     }
-
-    console.log(`[serverApi] retry after refresh → ${res.status}`)
   }
 
   return await handleResponse<T>(res, config)
@@ -188,4 +180,3 @@ export const serverApi = {
   delete: <T>(endpoint: string, config?: RequestConfig) =>
     serverFetch<T>('DELETE', endpoint, undefined, config),
 }
-


### PR DESCRIPTION
## 변경 사항

- accesToken 재 발급 -> 500 에러 발생 -> 토큰 삭제 안되고 무한 렌더링 발생하는 현상 수정

## 리뷰 필요

- 토큰 삭제 로직 리뷰 필요
-

close #15 
