### PR TITLE
feat: 인터뷰 질문 생성 및 AI 리포트 분석 이벤트 트래킹 추가

### DIFF
--- a/src/featured/history/components/HistoryContainer.tsx
+++ b/src/featured/history/components/HistoryContainer.tsx
@@ -100,6 +100,23 @@ function FlipCard({ record }: FlipCardProps) {
 
   // 상태 감별사 함수로 무슨 카드 보여줄지 결정
   const cardType = getReportCardType(record.intvStatus, record.report?.reportStatus)
+
+  const prevCardType = useRef(cardType)
+  
+  useEffect(() => {
+    // 1. 카드가 처음 'analysingCard(분석 중)'로 화면에 떴을 때 (Start)
+    if (cardType === 'analysingCard' && prevCardType.current !== 'analysingCard') {
+      sendGAEvent('event', 'report_gen_start', { category: 'ai_report' })
+    }
+    
+    // 2. '분석 중' 카드를 보며 기다리다가 'completedCard(분석 완료)'로 상태가 바뀌었을 때 (Complete)
+    if (prevCardType.current === 'analysingCard' && cardType === 'completedCard') {
+      sendGAEvent('event', 'report_gen_complete', { category: 'ai_report' })
+    }
+    
+    prevCardType.current = cardType
+  }, [cardType])
+
   //  추가할 부분: 보여줄 카드 타입이 없으면(null) 렌더링을 중단하고 아무것도 안 그림!
   if (!cardType) return null
   const isCompleted = cardType === 'completedCard'

--- a/src/featured/history/components/HistoryContainer.tsx
+++ b/src/featured/history/components/HistoryContainer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { motion } from 'framer-motion'
 import { Card } from '@/shared/ui/card'
@@ -16,6 +16,7 @@ import {
 import { FailedCard } from '@/featured/history/components/cards/FailedCard'
 import { PendingCard } from './cards/PendingCard'
 import { AnalysingCard } from './cards/AnalysingCard'
+import { sendGAEvent } from '@next/third-parties/google'
 
 // 3. 테스트용 목데이터 (이어하기 테스트 명확화 및 상태값 적용)
 // const MOCK_RECORDS: InterviewReportItem[] = [
@@ -101,23 +102,26 @@ function FlipCard({ record }: FlipCardProps) {
   // 상태 감별사 함수로 무슨 카드 보여줄지 결정
   const cardType = getReportCardType(record.intvStatus, record.report?.reportStatus)
 
-  const prevCardType = useRef(cardType)
-  
+  // 초기값을 null로 설정하여 과거 상태를 비워둡니다.
+  // 방금 화면에 들어왔습니다. 메모장은 비어있습니다. (prevCardType.current === null)
+  const prevCardType = useRef<string | null>(null)
+
   useEffect(() => {
-    // 1. 카드가 처음 'analysingCard(분석 중)'로 화면에 떴을 때 (Start)
+    // 1. 카드가 '분석 중' 상태로 렌더링 되었는데, 이전 상태가 '분석 중'이 아닐 때 (최초 진입 포함) (Start)
     if (cardType === 'analysingCard' && prevCardType.current !== 'analysingCard') {
       sendGAEvent('event', 'report_gen_start', { category: 'ai_report' })
     }
-    
-    // 2. '분석 중' 카드를 보며 기다리다가 'completedCard(분석 완료)'로 상태가 바뀌었을 때 (Complete)
+
+    // 2. 과거 상태가 '분석 중'이었는데, 지금 '분석 완료'로 상태가 바뀌었을 때 (Complete)
     if (prevCardType.current === 'analysingCard' && cardType === 'completedCard') {
       sendGAEvent('event', 'report_gen_complete', { category: 'ai_report' })
     }
-    
+
+    // 다음 상태 비교를 위해, 현재 상태를 '과거'로 메모지에 적어둠
     prevCardType.current = cardType
   }, [cardType])
 
-  //  추가할 부분: 보여줄 카드 타입이 없으면(null) 렌더링을 중단하고 아무것도 안 그림!
+  //  보여줄 카드 타입이 없으면(null) 렌더링을 중단하고 아무것도 안 그림
   if (!cardType) return null
   const isCompleted = cardType === 'completedCard'
 
@@ -179,9 +183,9 @@ export function HistoryContainer({
   // 테스트가 끝나면 다시 records로
   const pageRecords = records.slice(start, start + itemsPerPage)
 
-  // ❌ 수정 전:
+  // 수정 전:
   if (records.length === 0) {
-    // ✅ 수정 후: 목데이터를 기준으로 빈 화면인지 체크하도록 변경
+    // 수정 후: 목데이터를 기준으로 빈 화면인지 체크하도록 변경
     // if (pageRecords.length === 0) {
     if (search) {
       return (

--- a/src/featured/interview/components/InterviewSetupModal.tsx
+++ b/src/featured/interview/components/InterviewSetupModal.tsx
@@ -156,7 +156,8 @@ export function InterviewSetupModal({ session, isResume = false }: InterviewSetu
       }
 
       completeStep(2)
-      // 👉 [추가할 코드] 질문 생성이 시작되는 시점 (Start)
+
+      // 질문 생성을 기다리는 시간의 시작점 코드 추가 - GA 이벤트 전송
       sendGAEvent('event', 'question_gen_start', { category: 'ai_interview' })
       generateInterviewQuestionAction(session.interviewId).catch((err) => console.error(err))
     } catch (error: any) {

--- a/src/featured/interview/components/InterviewSetupModal.tsx
+++ b/src/featured/interview/components/InterviewSetupModal.tsx
@@ -26,6 +26,7 @@ import {
 import uploadFileToS3 from '@/shared/lib/utils/uploadFileToS3'
 import { useQuestionPolling } from '@/featured/interview/hooks/useQuestionPolling'
 import { toast } from 'sonner'
+import { sendGAEvent } from '@next/third-parties/google'
 
 interface InterviewSetupModalProps {
   session: ReturnType<typeof useInterview>
@@ -155,6 +156,8 @@ export function InterviewSetupModal({ session, isResume = false }: InterviewSetu
       }
 
       completeStep(2)
+      // 👉 [추가할 코드] 질문 생성이 시작되는 시점 (Start)
+      sendGAEvent('event', 'question_gen_start', { category: 'ai_interview' })
       generateInterviewQuestionAction(session.interviewId).catch((err) => console.error(err))
     } catch (error: any) {
       console.error('문서 업로드 중 오류:', error)

--- a/src/featured/interview/hooks/useQuestionPolling.ts
+++ b/src/featured/interview/hooks/useQuestionPolling.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { getInterviewQuestionsAction } from '@/featured/interview/actions/interview.action'
 import { useEffect } from 'react'
+import { sendGAEvent } from '@next/third-parties/google'
 
 export function useQuestionPolling(
   intvId: number | null,
@@ -31,7 +32,7 @@ export function useQuestionPolling(
   })
   useEffect(() => {
     if (query.data && query.data.length > 0) {
-
+      // 질문 생성 완료 (Complete)- GA 이벤트 전송
       sendGAEvent('event', 'question_gen_complete', { category: 'ai_interview' })
 
       handlePollingComplete()

--- a/src/featured/interview/hooks/useQuestionPolling.ts
+++ b/src/featured/interview/hooks/useQuestionPolling.ts
@@ -31,6 +31,9 @@ export function useQuestionPolling(
   })
   useEffect(() => {
     if (query.data && query.data.length > 0) {
+
+      sendGAEvent('event', 'question_gen_complete', { category: 'ai_interview' })
+
       handlePollingComplete()
     }
   }, [query.data, handlePollingComplete])


### PR DESCRIPTION
## 변경 사항

- 인터뷰 질문 생성 단계에 Start / Complete 이벤트 추가
   - S3 업로드 후 질문 생성 요청 시점에 Start 이벤트 발생
   - 질문 폴링 성공 시 Complete 이벤트 발생
- AI 리포트 분석 단계 이벤트 트래킹 추가
  - History 화면에서 카드 상태(cardType) 변화를 감지하여 Start / Complete 이벤트 처리

## 리뷰 필요

- 이벤트 발생 시점이 의도한 사용자 흐름과 정확히 맞는지 확인 
- 카드 상태 변화 기반 트래킹 방식이 적절한지 검토

close #17 
