### PR TITLE
feat: ga4 이벤트 유틸리티

### DIFF
--- a/src/featured/history/components/HistoryContainer.tsx
+++ b/src/featured/history/components/HistoryContainer.tsx
@@ -16,7 +16,9 @@ import {
 import { FailedCard } from '@/featured/history/components/cards/FailedCard'
 import { PendingCard } from './cards/PendingCard'
 import { AnalysingCard } from './cards/AnalysingCard'
+import { trackEvent } from '@/shared/lib/utils/analytics'
 import { sendGAEvent } from '@next/third-parties/google'
+import { tr, track } from 'framer-motion/client'
 
 // 3. 테스트용 목데이터 (이어하기 테스트 명확화 및 상태값 적용)
 // const MOCK_RECORDS: InterviewReportItem[] = [
@@ -107,14 +109,14 @@ function FlipCard({ record }: FlipCardProps) {
   const prevCardType = useRef<string | null>(null)
 
   useEffect(() => {
-    // 1. 카드가 '분석 중' 상태로 렌더링 되었는데, 이전 상태가 '분석 중'이 아닐 때 (최초 진입 포함) (Start)
+    // 1. 리포트 생성 시작 시 (Start)
     if (cardType === 'analysingCard' && prevCardType.current !== 'analysingCard') {
-      sendGAEvent('event', 'report_gen_start', { category: 'ai_report' })
+      trackEvent('report_gen_start', { category: 'ai_report' })
     }
 
-    // 2. 과거 상태가 '분석 중'이었는데, 지금 '분석 완료'로 상태가 바뀌었을 때 (Complete)
+    // 2. 리포트 생성 완료 시 (Complete)
     if (prevCardType.current === 'analysingCard' && cardType === 'completedCard') {
-      sendGAEvent('event', 'report_gen_complete', { category: 'ai_report' })
+      trackEvent('report_gen_complete', { category: 'ai_report' })
     }
 
     // 다음 상태 비교를 위해, 현재 상태를 '과거'로 메모지에 적어둠

--- a/src/featured/interview/components/InterviewSetupModal.tsx
+++ b/src/featured/interview/components/InterviewSetupModal.tsx
@@ -26,7 +26,9 @@ import {
 import uploadFileToS3 from '@/shared/lib/utils/uploadFileToS3'
 import { useQuestionPolling } from '@/featured/interview/hooks/useQuestionPolling'
 import { toast } from 'sonner'
-import { sendGAEvent } from '@next/third-parties/google'
+import { trackEvent } from '@/shared/lib/utils/analytics'
+import { title } from 'process'
+import { resume } from 'react-dom/server'
 
 interface InterviewSetupModalProps {
   session: ReturnType<typeof useInterview>
@@ -158,11 +160,16 @@ export function InterviewSetupModal({ session, isResume = false }: InterviewSetu
       completeStep(2)
 
       // 질문 생성을 기다리는 시간의 시작점 코드 추가 - GA 이벤트 전송
-      sendGAEvent('event', 'question_gen_start', { category: 'ai_interview' })
+      trackEvent('question_gen_start', { category: 'ai_interview' })
       generateInterviewQuestionAction(session.interviewId).catch((err) => console.error(err))
-    } catch (error: any) {
+    } catch (error) {
+      // 1. 명시적인 : any를 제거합니다. (기본적으로 unknown 타입이 됩니다)
       console.error('문서 업로드 중 오류:', error)
-      toast.error(error.message || '문서 업로드 중 오류 발생')
+
+      // 2. error가 Error 객체의 인스턴스인지 확인하여 안전하게 message를 꺼냅니다.
+      const errorMessage = error instanceof Error ? error.message : '문서 업로드 중 오류 발생'
+
+      toast.error(errorMessage)
     } finally {
       setIsUploading(false)
     }

--- a/src/featured/interview/components/InterviewSetupModal.tsx
+++ b/src/featured/interview/components/InterviewSetupModal.tsx
@@ -27,8 +27,6 @@ import uploadFileToS3 from '@/shared/lib/utils/uploadFileToS3'
 import { useQuestionPolling } from '@/featured/interview/hooks/useQuestionPolling'
 import { toast } from 'sonner'
 import { trackEvent } from '@/shared/lib/utils/analytics'
-import { title } from 'process'
-import { resume } from 'react-dom/server'
 
 interface InterviewSetupModalProps {
   session: ReturnType<typeof useInterview>

--- a/src/featured/interview/components/setup/DocumentStep.tsx
+++ b/src/featured/interview/components/setup/DocumentStep.tsx
@@ -1,8 +1,7 @@
 import { FolderOpen, ChevronRight, CheckCircle2, Upload, X } from 'lucide-react'
 import { Button } from '@/shared/ui/button'
 import { useEffect } from 'react'
-import { sendGAEvent } from '@next/third-parties/google'
-
+import { trackFunnel } from '@/shared/lib/utils/analytics'
 interface DocumentStepProps {
   resume: File | null
   portfolio: File | null
@@ -24,9 +23,9 @@ export function DocumentStep({
   onComplete,
   isUploading,
 }: DocumentStepProps) {
-  //  GA4 이벤트 전송 코드 추가
+  // GA4 이벤트 전송 코드 수정 (중복 제거 및 단축키 사용)
   useEffect(() => {
-    sendGAEvent('event', 'enter_upload_page', { category: 'funnel' })
+    trackFunnel('enter_upload_page')
   }, [])
 
   const canComplete = !!resume

--- a/src/featured/interview/components/setup/DocumentStep.tsx
+++ b/src/featured/interview/components/setup/DocumentStep.tsx
@@ -1,5 +1,7 @@
 import { FolderOpen, ChevronRight, CheckCircle2, Upload, X } from 'lucide-react'
 import { Button } from '@/shared/ui/button'
+import { useEffect } from 'react'
+import { sendGAEvent } from '@next/third-parties/google'
 
 interface DocumentStepProps {
   resume: File | null
@@ -22,6 +24,11 @@ export function DocumentStep({
   onComplete,
   isUploading,
 }: DocumentStepProps) {
+  //  GA4 이벤트 전송 코드 추가
+  useEffect(() => {
+    sendGAEvent('event', 'enter_upload_page', { category: 'funnel' })
+  }, [])
+
   const canComplete = !!resume
   const handleFileChange =
     (setter: (f: File | null) => void) => (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/featured/interview/hooks/useQuestionPolling.ts
+++ b/src/featured/interview/hooks/useQuestionPolling.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { getInterviewQuestionsAction } from '@/featured/interview/actions/interview.action'
 import { useEffect } from 'react'
-import { sendGAEvent } from '@next/third-parties/google'
+import { trackEvent } from '@/shared/lib/utils/analytics'
 
 export function useQuestionPolling(
   intvId: number | null,
@@ -30,13 +30,15 @@ export function useQuestionPolling(
     staleTime: 0, // 신선도
     retry: 2, // 재시도
   })
+
   useEffect(() => {
     if (query.data && query.data.length > 0) {
-      // 질문 생성 완료 (Complete)- GA 이벤트 전송
-      sendGAEvent('event', 'question_gen_complete', { category: 'ai_interview' })
+      // 질문 생성 완료 (Complete)- GA 이벤트 전송 (trackEvent 적용)
+      trackEvent('question_gen_complete', { category: 'ai_interview' })
 
       handlePollingComplete()
     }
   }, [query.data, handlePollingComplete])
+
   return query
 }

--- a/src/shared/lib/utils/analytics.ts
+++ b/src/shared/lib/utils/analytics.ts
@@ -1,22 +1,33 @@
 import { sendGAEvent } from '@next/third-parties/google'
 
 // 기획 단계에서 정의한 이벤트 명세
-type FunnelStep = 
-  | 'enter_upload_page' 
-  | 'upload_s3_success' 
-  | 'upload_s3_error'
-  | 'mic_permission_denied'
-  | 'cam_permission_denied'
-  | 'start_interview';
+type FunnelStep =
+  // 1. AI 대기 및 리포트 관련 이벤트들
+  | 'question_gen_start' // 질문 생성 시작
+  | 'question_gen_complete' // 질문 생성 완료
+  | 'report_gen_start' // 리포트 생성 시작
+  | 'report_gen_complete' // 리포트 생성 완료 (여기 있던 세미콜론 제거)
 
-type EventParams = Record<string, string | number | boolean>;
+  // 2. 파일 업로드 플로우
+  | 'enter_upload_page' // 파일 업로드 페이지 진입
+  | 'upload_s3_success' // S3 업로드 성공
+  | 'upload_s3_error' // S3 업로드 실패 (여기 있던 세미콜론 제거)
+
+  // 3. 디바이스 권한 및 면접 시작 (누락되었던 granted 추가!)
+  | 'mic_permission_granted' // 마이크 권한 허용
+  | 'mic_permission_denied' // 마이크 권한 거부
+  | 'cam_permission_granted' // 카메라 권한 허용
+  | 'cam_permission_denied' // 카메라 권한 거부
+  | 'start_interview' // 면접 시작 완료 (맨 마지막에만 세미콜론!)
+
+type EventParams = Record<string, string | number | boolean>
 
 // string 대신 FunnelStep 타입을 적용
 export const trackEvent = (eventName: FunnelStep | string, params?: EventParams) => {
-  sendGAEvent('event', eventName, params || {});
+  sendGAEvent('event', eventName, params || {})
 }
 
 // 퍼널 함수에는 더 엄격하게 FunnelStep 타입만 허용
 export const trackFunnel = (stepName: FunnelStep) => {
-  trackEvent(stepName, { category: 'funnel' });
+  trackEvent(stepName, { category: 'funnel' })
 }

--- a/src/shared/lib/utils/analytics.ts
+++ b/src/shared/lib/utils/analytics.ts
@@ -6,19 +6,17 @@ type FunnelStep =
   | 'question_gen_start' // 질문 생성 시작
   | 'question_gen_complete' // 질문 생성 완료
   | 'report_gen_start' // 리포트 생성 시작
-  | 'report_gen_complete' // 리포트 생성 완료 (여기 있던 세미콜론 제거)
+  | 'report_gen_complete' // 리포트 생성 완료
 
-  // 2. 파일 업로드 플로우
+  // 2. 파일 업로드 및 면접 시작 플로우 점검
   | 'enter_upload_page' // 파일 업로드 페이지 진입
   | 'upload_s3_success' // S3 업로드 성공
-  | 'upload_s3_error' // S3 업로드 실패 (여기 있던 세미콜론 제거)
-
-  // 3. 디바이스 권한 및 면접 시작 (누락되었던 granted 추가!)
+  | 'upload_s3_error' // S3 업로드 실패
   | 'mic_permission_granted' // 마이크 권한 허용
   | 'mic_permission_denied' // 마이크 권한 거부
   | 'cam_permission_granted' // 카메라 권한 허용
   | 'cam_permission_denied' // 카메라 권한 거부
-  | 'start_interview' // 면접 시작 완료 (맨 마지막에만 세미콜론!)
+  | 'start_interview' // 면접 시작 완료
 
 type EventParams = Record<string, string | number | boolean>
 

--- a/src/shared/lib/utils/analytics.ts
+++ b/src/shared/lib/utils/analytics.ts
@@ -1,0 +1,22 @@
+import { sendGAEvent } from '@next/third-parties/google'
+
+// 기획 단계에서 정의한 이벤트 명세
+type FunnelStep = 
+  | 'enter_upload_page' 
+  | 'upload_s3_success' 
+  | 'upload_s3_error'
+  | 'mic_permission_denied'
+  | 'cam_permission_denied'
+  | 'start_interview';
+
+type EventParams = Record<string, string | number | boolean>;
+
+// string 대신 FunnelStep 타입을 적용
+export const trackEvent = (eventName: FunnelStep | string, params?: EventParams) => {
+  sendGAEvent('event', eventName, params || {});
+}
+
+// 퍼널 함수에는 더 엄격하게 FunnelStep 타입만 허용
+export const trackFunnel = (stepName: FunnelStep) => {
+  trackEvent(stepName, { category: 'funnel' });
+}


### PR DESCRIPTION
## 변경 사항

- GA4 이벤트 전송 공통 유틸리티 구현 (analytics.ts)
- 주요 퍼널 및 마찰 지점(에러) 이벤트 연동 완료
- InterviewSetupModal 에러수정, 공통 유틸 trackEvent ('question_gen_start' )로 교체
- useQuestionPolling: AI 질문 생성 완료 시 기존 구글 순정 함수를 새로 구현한 공통 유틸 trackEvent('question_gen_complete')로 교체 완료
- HistoryContainer: AI 리포트 분석 시작 및 완료 시점의 이벤트를 공통 유틸 trackEvent 기반의 'report_gen_start', 'report_gen_complete'로 리팩토링 완료
- DocumentStep: 파일 업로드 페이지 진입 시 enter_upload_page 이벤트 전송 로직 추가  

## 리뷰 필요

- analytics.ts에 정의된 FunnelStep 타입 
- InterviewSetupModal.tsx
- useQuestionPolling.ts
- HistoryContainer.tsx
- DocumentStep.tsx


close #28 
