### PR TITLE
feat: ga4) 로딩 중 비활성 탭 전환 감지 기능 추가

### DIFF
--- a/src/featured/history/components/cards/AnalysingCard.tsx
+++ b/src/featured/history/components/cards/AnalysingCard.tsx
@@ -1,7 +1,9 @@
 import { motion } from 'framer-motion'
 import { RotateCw } from 'lucide-react'
+import { useTabSwitchTracker } from '../../hooks/useTabSwitchTracker'
 
 export function AnalysingCard() {
+  useTabSwitchTracker(true)
   return (
     <div className="flex h-full flex-col items-center justify-center p-3 text-center @[180px]:p-4 @[220px]:p-5 @[280px]:p-6">
       <div className="mb-2 rounded-full bg-yellow-100 p-3 @[180px]:mb-3 @[180px]:p-4 @[220px]:p-5 @[280px]:mb-4 @[280px]:p-6">

--- a/src/featured/history/hooks/useTabSwitchTracker.ts
+++ b/src/featured/history/hooks/useTabSwitchTracker.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from 'react'
+import { trackFunnel } from '@/shared/lib/utils/analytics'
+
+export const useTabSwitchTracker = (isTrackingActive: boolean) => {
+  // 이미 이벤트를 쐈는지 기억하는 메모지 (리렌더링되어도 값이 유지됨)
+  const hasTracked = useRef(false)
+
+  useEffect(() => {
+    if (!isTrackingActive) return
+
+    // 추적이 새로 켜질 때마다 메모지를 초기화
+    hasTracked.current = false
+
+    const handleVisibilityChange = () => {
+      // 탭이 숨겨졌고 && 아직 이벤트를 안 쐈을 때만 실행
+      if (document.hidden && !hasTracked.current) {
+        trackFunnel('loading_tab_leave')
+        hasTracked.current = true // "이제 쐈다!" 라고 표시
+      }
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [isTrackingActive])
+}

--- a/src/shared/lib/utils/analytics.ts
+++ b/src/shared/lib/utils/analytics.ts
@@ -7,6 +7,7 @@ type FunnelStep =
   | 'question_gen_complete' // 질문 생성 완료
   | 'report_gen_start' // 리포트 생성 시작
   | 'report_gen_complete' // 리포트 생성 완료
+  | 'loading_tab_leave' // 리포트 발행 로딩 중 탭 이탈
 
   // 2. 파일 업로드 및 면접 시작 플로우 점검
   | 'open_interview_modal' // 모달창 최초 진입 (1단계)


### PR DESCRIPTION
## 변경 사항

- 로딩 중 비활성 탭 전환 감지 코드 추가

## 리뷰 필요

- analytics.ts (FunnelStep 타입에  loading_tab_hidden 이벤트 추가) 
- useTabSwitchTracker.ts 파일생성
- src/featured/history/components/cards/AnalysingCard.tsx (useTabSwitchTracker 훅 코드추가) 

close #40 
