### PR TITLE
fix : 분노의클릭 마찰율로 감지하도록 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -65,7 +65,10 @@ export default function RootLayout({
         <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="anonymous" />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}>
-        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID || ''} />
+        <GoogleAnalytics
+          gaId={process.env.NEXT_PUBLIC_GA_ID || ''}
+          debugMode={process.env.NODE_ENV === 'development'}
+        />
         <ClarityProvider clarityId={process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID || ''} />
         <ReactQueryProvider>
           <TooltipProvider delayDuration={300}>{children}</TooltipProvider>

--- a/src/featured/history/components/HistoryContainer.tsx
+++ b/src/featured/history/components/HistoryContainer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { motion } from 'framer-motion'
 import { Card } from '@/shared/ui/card'
@@ -34,42 +34,90 @@ function FlipCard({ record }: FlipCardProps) {
   const router = useRouter()
   const [isHovered, setIsHovered] = useState(false)
 
-  // 상태 감별사 함수로 무슨 카드 보여줄지 결정
   const cardType = getReportCardType(record.intvStatus, record.report?.reportStatus)
 
-  // 초기값을 null로 설정하여 과거 상태를 비워둡니다.
-  // 방금 화면에 들어왔습니다. 메모장은 비어있습니다. (prevCardType.current === null)
   const prevCardType = useRef<string | null>(null)
 
-  useEffect(() => {
-    // 1. 리포트 생성 시작 시 (Start)
-    if (cardType === 'analysingCard' && prevCardType.current !== 'analysingCard') {
-      trackEvent('report_gen_start', { category: 'ai_report' })
-    }
-
-    // 2. 리포트 생성 완료 시 (Complete)
-    if (prevCardType.current === 'analysingCard' && cardType === 'completedCard') {
-      trackEvent('report_gen_complete', { category: 'ai_report' })
-    }
-
-    // 다음 상태 비교를 위해, 현재 상태를 '과거'로 메모지에 적어둠
-    prevCardType.current = cardType
-  }, [cardType])
-
-  //  보여줄 카드 타입이 없으면(null) 렌더링을 중단하고 아무것도 안 그림
-  if (!cardType) return null
+  // 카드 상태 분리
   const isCompleted = cardType === 'completedCard'
+  const isAnalysing = cardType === 'analysingCard'
 
-  const handleClick = () => {
-    // 분석 완료 카드만 상세 페이지로 이동 가능
+  // 이벤트 payload에서 반복해서 쓸 id 분리
+  const reportId = record.report?.reportId
+  const intvId = record.intvId
+
+  useEffect(() => {
+    if (cardType === 'analysingCard' && prevCardType.current !== 'analysingCard') {
+      // 기존 이벤트 유지
+      trackEvent('report_gen_start', {
+        category: 'ai_report',
+      })
+
+      // 백오피스 마찰률 분모 이벤트
+      // 전체 리포트 대기 세션 수를 계산할 때 사용
+      trackEvent('report_waiting_session', {
+        category: 'ai_report',
+        report_id: reportId ?? '',
+        intv_id: intvId,
+        page: 'history',
+        status: 'generating',
+      })
+    }
+
+    if (prevCardType.current === 'analysingCard' && cardType === 'completedCard') {
+      trackEvent('report_gen_complete', {
+        category: 'ai_report',
+      })
+    }
+
+    prevCardType.current = cardType
+  }, [cardType, reportId, intvId])
+
+  // 분석 중 카드에서만 분노 클릭 이벤트 전송
+  const handleRageClick = useCallback(() => {
+    if (!isAnalysing) return
+
+    // 백오피스 마찰률 분자 이벤트
+    // "2초 안에 3번 클릭"이 감지됐을 때만 실행됨
+    trackEvent('report_waiting_rage_click', {
+      category: 'user_frustration',
+      report_id: reportId ?? '',
+      intv_id: intvId,
+      page: 'history',
+      status: 'generating',
+      click_count: 3,
+      window_ms: 2000,
+    })
+
+    // Clarity 스마트 이벤트명도 백오피스 기준과 맞춤
+    if (typeof window !== 'undefined' && typeof window.clarity === 'function') {
+      window.clarity('event', 'report_waiting_rage_click')
+    }
+  }, [isAnalysing, reportId, intvId])
+
+  // useRageClick을 FlipCard 내부로 이동
+  // React 훅 규칙상 조건문 안에서 호출하면 안 되므로 항상 호출하고,
+  // 실제 실행은 handleCardClick에서 isAnalysing일 때만 함
+  const { handleContainerClick } = useRageClick(handleRageClick)
+
+  if (!cardType) return null
+
+  // 완료 카드 클릭과 분석 중 카드 클릭을 하나의 핸들러에서 분기
+  const handleCardClick = () => {
     if (isCompleted) {
       router.push(`/report/${record.intvId}`)
+      return
+    }
+
+    // 분석 중 카드일 때만 rage click 카운트 증가
+    if (isAnalysing) {
+      handleContainerClick()
     }
   }
 
   return (
     <div
-      onClick={handleClick}
+      onClick={handleCardClick}
       onMouseEnter={() => {
         if (isCompleted) {
           setIsHovered(true)
@@ -89,6 +137,7 @@ function FlipCard({ record }: FlipCardProps) {
           {cardType === 'analysingCard' && <AnalysingCard />}
           {cardType === 'failedCard' && <FailedCard record={record} />}
         </Card>
+
         {isCompleted && (
           <Card
             className="absolute inset-0 overflow-hidden antialiased backface-hidden"
@@ -108,47 +157,10 @@ export function HistoryContainer({
   currentPage,
   itemsPerPage,
 }: HistoryContainerProps) {
-  // 면접 데이터 없게 들어오는지 test
-  console.log('실제 API에서 넘어온 면접 데이터:', records)
-
   const start = (currentPage - 1) * itemsPerPage
-
-  // 잠시 테스트를 위해 records 대신 MOCK_RECORDS를 사용하도록 변경
-  // const pageRecords = MOCK_RECORDS.slice(start, start + itemsPerPage)
-  // 테스트가 끝나면 다시 records로
   const pageRecords = records.slice(start, start + itemsPerPage)
 
-  // 1. 현재 화면에 'AI 리포트 분석 중'인 카드가 한 개라도 존재하는지 실시간 체크
-  const hasAnalysingCard = pageRecords.some(
-    (record) =>
-      getReportCardType(record.intvStatus, record.report?.reportStatus) === 'analysingCard',
-  )
-
-  // 2. 분노 클릭 조건 만족 시 실행할 통합 전송 핸들러
-  const handleRageClick = () => {
-    // 분석 중인 카드가 화면에 있을 때만 이벤트를 발송합니다.
-    if (!hasAnalysingCard) return
-
-    // [GA4 전송] - 명세서에 등록한 'rage_click' 이벤트 발송
-    trackEvent('rage_click', {
-      category: 'user_frustration',
-      label: 'ai_report_waiting',
-      screen_name: 'history_page_global',
-    })
-
-    // [MS Clarity 스마트 연동] - 대시보드 커스텀 필터용 타겟팅 이벤트
-    if (typeof window !== 'undefined' && typeof window.clarity === 'function') {
-      window.clarity('event', 'rage_click')
-    }
-  }
-
-  //  3. useRageClick 훅 활용
-  const { handleContainerClick } = useRageClick(handleRageClick)
-
-  // 수정 전:
   if (records.length === 0) {
-    // 수정 후: 목데이터를 기준으로 빈 화면인지 체크하도록 변경
-    // if (pageRecords.length === 0) {
     if (search) {
       return (
         <motion.div
@@ -197,10 +209,7 @@ export function HistoryContainer({
   }
 
   return (
-    <div
-      onClick={handleContainerClick}
-      className="grid grid-cols-2 gap-4 sm:grid-cols-3 sm:gap-5 lg:grid-cols-4 xl:grid-cols-5"
-    >
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 sm:gap-5 lg:grid-cols-4 xl:grid-cols-5">
       {pageRecords.map((record, i) => (
         <motion.div
           key={record.intvId}

--- a/src/featured/history/components/HistoryContainer.tsx
+++ b/src/featured/history/components/HistoryContainer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { motion } from 'framer-motion'
 import { Card } from '@/shared/ui/card'
@@ -34,42 +34,87 @@ function FlipCard({ record }: FlipCardProps) {
   const router = useRouter()
   const [isHovered, setIsHovered] = useState(false)
 
-  // 상태 감별사 함수로 무슨 카드 보여줄지 결정
   const cardType = getReportCardType(record.intvStatus, record.report?.reportStatus)
 
-  // 초기값을 null로 설정하여 과거 상태를 비워둡니다.
-  // 방금 화면에 들어왔습니다. 메모장은 비어있습니다. (prevCardType.current === null)
   const prevCardType = useRef<string | null>(null)
 
-  useEffect(() => {
-    // 1. 리포트 생성 시작 시
-    if (cardType === 'analysingCard' && prevCardType.current !== 'analysingCard') {
-      trackEvent('report_gen_start', { category: 'ai_report' })
-    }
-
-    // 2. 리포트 생성 완료 시
-    if (prevCardType.current === 'analysingCard' && cardType === 'completedCard') {
-      trackEvent('report_gen_complete', { category: 'ai_report' })
-    }
-
-    // 다음 상태 비교를 위해, 현재 상태를 '과거'로 메모지에 적어둠
-    prevCardType.current = cardType
-  }, [cardType])
-
-  //  보여줄 카드 타입이 없으면(null) 렌더링을 중단하고 아무것도 안 그림
-  if (!cardType) return null
+  // 카드 상태를 boolean으로 분리
   const isCompleted = cardType === 'completedCard'
+  const isAnalysing = cardType === 'analysingCard'
 
-  const handleClick = () => {
-    // 분석 완료 카드만 상세 페이지로 이동 가능
+  // 이벤트 payload에서 반복해서 쓸 id 분리
+  const reportId = record.report?.reportId
+  const intvId = record.intvId
+
+  useEffect(() => {
+    if (cardType === 'analysingCard' && prevCardType.current !== 'analysingCard') {
+      trackEvent('report_gen_start', {
+        category: 'ai_report',
+        report_id: reportId ?? '',
+        intv_id: intvId,
+      })
+
+      trackEvent('report_waiting_session', {
+        category: 'ai_report',
+        report_id: reportId ?? '',
+        intv_id: intvId,
+        page: 'history',
+        status: 'generating',
+      })
+    }
+
+    if (prevCardType.current === 'analysingCard' && cardType === 'completedCard') {
+      trackEvent('report_gen_complete', {
+        category: 'ai_report',
+        report_id: reportId ?? '',
+        intv_id: intvId,
+      })
+    }
+
+    prevCardType.current = cardType
+  }, [cardType, reportId, intvId])
+
+  const handleRageClick = useCallback(() => {
+    if (!isAnalysing) return
+
+    trackEvent(
+      'report_waiting_rage_click',
+      {
+        category: 'user_frustration',
+        report_id: reportId ?? '',
+        intv_id: intvId,
+        page: 'history',
+        status: 'generating',
+        click_count: 3,
+        window_ms: 2000,
+      },
+      { clarity: true },
+    )
+  }, [isAnalysing, reportId, intvId])
+
+  // useRageClick을 FlipCard 내부로 이동
+  // React 훅 규칙상 조건문 안에서 호출하면 안 되므로 항상 호출하고,
+  // 실제 실행은 handleCardClick에서 isAnalysing일 때만 함
+  const { handleContainerClick } = useRageClick(handleRageClick)
+
+  if (!cardType) return null
+
+  // 완료 카드 클릭과 분석 중 카드 클릭을 하나의 핸들러에서 분기
+  const handleCardClick = () => {
     if (isCompleted) {
       router.push(`/report/${record.intvId}`)
+      return
+    }
+
+    //  분석 중 카드일 때만 rage click 카운트 증가
+    if (isAnalysing) {
+      handleContainerClick()
     }
   }
 
   return (
     <div
-      onClick={handleClick}
+      onClick={handleCardClick}
       onMouseEnter={() => {
         if (isCompleted) {
           setIsHovered(true)
@@ -89,6 +134,7 @@ function FlipCard({ record }: FlipCardProps) {
           {cardType === 'analysingCard' && <AnalysingCard />}
           {cardType === 'failedCard' && <FailedCard record={record} />}
         </Card>
+
         {isCompleted && (
           <Card
             className="absolute inset-0 overflow-hidden antialiased backface-hidden"
@@ -108,47 +154,10 @@ export function HistoryContainer({
   currentPage,
   itemsPerPage,
 }: HistoryContainerProps) {
-  // 면접 데이터 없게 들어오는지 test
-  console.log('실제 API에서 넘어온 면접 데이터:', records)
-
   const start = (currentPage - 1) * itemsPerPage
-
-  // 잠시 테스트를 위해 records 대신 MOCK_RECORDS를 사용하도록 변경
-  // const pageRecords = MOCK_RECORDS.slice(start, start + itemsPerPage)
-  // 테스트가 끝나면 다시 records로
   const pageRecords = records.slice(start, start + itemsPerPage)
 
-  // 1. 현재 화면에 'AI 리포트 분석 중'인 카드가 한 개라도 존재하는지 실시간 체크
-  const hasAnalysingCard = pageRecords.some(
-    (record) =>
-      getReportCardType(record.intvStatus, record.report?.reportStatus) === 'analysingCard',
-  )
-
-  // 2. 분노 클릭 조건 만족 시 실행할 통합 전송 핸들러
-  const handleRageClick = () => {
-    // 분석 중인 카드가 화면에 있을 때만 이벤트를 발송합니다.
-    if (!hasAnalysingCard) return
-
-    // [GA4 전송] - 명세서에 등록한 'rage_click' 이벤트 발송
-    trackEvent('rage_click', {
-      category: 'user_frustration',
-      label: 'ai_report_waiting',
-      screen_name: 'history_page_global',
-    })
-
-    // [MS Clarity 스마트 연동] - 대시보드 커스텀 필터용 타겟팅 이벤트
-    if (typeof window !== 'undefined' && typeof window.clarity === 'function') {
-      window.clarity('event', 'rage_click')
-    }
-  }
-
-  //  3. useRageClick 훅 활용
-  const { handleContainerClick } = useRageClick(handleRageClick)
-
-  // 수정 전:
   if (records.length === 0) {
-    // 수정 후: 목데이터를 기준으로 빈 화면인지 체크하도록 변경
-    // if (pageRecords.length === 0) {
     if (search) {
       return (
         <motion.div

--- a/src/featured/history/components/HistoryContainer.tsx
+++ b/src/featured/history/components/HistoryContainer.tsx
@@ -41,6 +41,7 @@ function FlipCard({ record }: FlipCardProps) {
   const isCompleted = cardType === 'completedCard'
   const isAnalysing = cardType === 'analysingCard'
 
+  // AI 리포트 대기 마찰률: 리포트 단위 기준
   const reportId = record.report?.reportId
 
   useEffect(() => {
@@ -52,6 +53,7 @@ function FlipCard({ record }: FlipCardProps) {
 
       const waitingSessionKey = `report_waiting_session:${reportId}`
 
+      // 마찰률의 분모 이벤트, 같은 리포트 대기 건은 세션 내 1회만 잡음
       if (!sessionStorage.getItem(waitingSessionKey)) {
         sessionStorage.setItem(waitingSessionKey, 'true')
 
@@ -77,6 +79,7 @@ function FlipCard({ record }: FlipCardProps) {
   const handleRageClick = useCallback(() => {
     if (!isAnalysing || !reportId) return
 
+    // 분석 중 카드에서 2초 내 3회 클릭  감지되면 마찰 이벤트로 전송
     trackEvent(
       'report_waiting_rage_click',
       {
@@ -91,6 +94,7 @@ function FlipCard({ record }: FlipCardProps) {
     )
   }, [isAnalysing, reportId])
 
+  // 분노의 클릭 카운트 : 분석 중 카드 클릭에서만 수행
   const { registerRageClick } = useRageClick(handleRageClick)
 
   if (!cardType) return null
@@ -101,6 +105,7 @@ function FlipCard({ record }: FlipCardProps) {
       return
     }
 
+    //  분석 중 카드 영역 클릭만 rage click 카운트 등록
     if (isAnalysing) {
       registerRageClick()
     }

--- a/src/featured/history/components/HistoryContainer.tsx
+++ b/src/featured/history/components/HistoryContainer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { motion } from 'framer-motion'
 import { Card } from '@/shared/ui/card'
@@ -34,90 +34,42 @@ function FlipCard({ record }: FlipCardProps) {
   const router = useRouter()
   const [isHovered, setIsHovered] = useState(false)
 
+  // 상태 감별사 함수로 무슨 카드 보여줄지 결정
   const cardType = getReportCardType(record.intvStatus, record.report?.reportStatus)
 
+  // 초기값을 null로 설정하여 과거 상태를 비워둡니다.
+  // 방금 화면에 들어왔습니다. 메모장은 비어있습니다. (prevCardType.current === null)
   const prevCardType = useRef<string | null>(null)
 
-  // 카드 상태 분리
-  const isCompleted = cardType === 'completedCard'
-  const isAnalysing = cardType === 'analysingCard'
-
-  // 이벤트 payload에서 반복해서 쓸 id 분리
-  const reportId = record.report?.reportId
-  const intvId = record.intvId
-
   useEffect(() => {
+    // 1. 리포트 생성 시작 시
     if (cardType === 'analysingCard' && prevCardType.current !== 'analysingCard') {
-      // 기존 이벤트 유지
-      trackEvent('report_gen_start', {
-        category: 'ai_report',
-      })
-
-      // 백오피스 마찰률 분모 이벤트
-      // 전체 리포트 대기 세션 수를 계산할 때 사용
-      trackEvent('report_waiting_session', {
-        category: 'ai_report',
-        report_id: reportId ?? '',
-        intv_id: intvId,
-        page: 'history',
-        status: 'generating',
-      })
+      trackEvent('report_gen_start', { category: 'ai_report' })
     }
 
+    // 2. 리포트 생성 완료 시
     if (prevCardType.current === 'analysingCard' && cardType === 'completedCard') {
-      trackEvent('report_gen_complete', {
-        category: 'ai_report',
-      })
+      trackEvent('report_gen_complete', { category: 'ai_report' })
     }
 
+    // 다음 상태 비교를 위해, 현재 상태를 '과거'로 메모지에 적어둠
     prevCardType.current = cardType
-  }, [cardType, reportId, intvId])
+  }, [cardType])
 
-  // 분석 중 카드에서만 분노 클릭 이벤트 전송
-  const handleRageClick = useCallback(() => {
-    if (!isAnalysing) return
-
-    // 백오피스 마찰률 분자 이벤트
-    // "2초 안에 3번 클릭"이 감지됐을 때만 실행됨
-    trackEvent('report_waiting_rage_click', {
-      category: 'user_frustration',
-      report_id: reportId ?? '',
-      intv_id: intvId,
-      page: 'history',
-      status: 'generating',
-      click_count: 3,
-      window_ms: 2000,
-    })
-
-    // Clarity 스마트 이벤트명도 백오피스 기준과 맞춤
-    if (typeof window !== 'undefined' && typeof window.clarity === 'function') {
-      window.clarity('event', 'report_waiting_rage_click')
-    }
-  }, [isAnalysing, reportId, intvId])
-
-  // useRageClick을 FlipCard 내부로 이동
-  // React 훅 규칙상 조건문 안에서 호출하면 안 되므로 항상 호출하고,
-  // 실제 실행은 handleCardClick에서 isAnalysing일 때만 함
-  const { handleContainerClick } = useRageClick(handleRageClick)
-
+  //  보여줄 카드 타입이 없으면(null) 렌더링을 중단하고 아무것도 안 그림
   if (!cardType) return null
+  const isCompleted = cardType === 'completedCard'
 
-  // 완료 카드 클릭과 분석 중 카드 클릭을 하나의 핸들러에서 분기
-  const handleCardClick = () => {
+  const handleClick = () => {
+    // 분석 완료 카드만 상세 페이지로 이동 가능
     if (isCompleted) {
       router.push(`/report/${record.intvId}`)
-      return
-    }
-
-    // 분석 중 카드일 때만 rage click 카운트 증가
-    if (isAnalysing) {
-      handleContainerClick()
     }
   }
 
   return (
     <div
-      onClick={handleCardClick}
+      onClick={handleClick}
       onMouseEnter={() => {
         if (isCompleted) {
           setIsHovered(true)
@@ -137,7 +89,6 @@ function FlipCard({ record }: FlipCardProps) {
           {cardType === 'analysingCard' && <AnalysingCard />}
           {cardType === 'failedCard' && <FailedCard record={record} />}
         </Card>
-
         {isCompleted && (
           <Card
             className="absolute inset-0 overflow-hidden antialiased backface-hidden"
@@ -157,10 +108,47 @@ export function HistoryContainer({
   currentPage,
   itemsPerPage,
 }: HistoryContainerProps) {
+  // 면접 데이터 없게 들어오는지 test
+  console.log('실제 API에서 넘어온 면접 데이터:', records)
+
   const start = (currentPage - 1) * itemsPerPage
+
+  // 잠시 테스트를 위해 records 대신 MOCK_RECORDS를 사용하도록 변경
+  // const pageRecords = MOCK_RECORDS.slice(start, start + itemsPerPage)
+  // 테스트가 끝나면 다시 records로
   const pageRecords = records.slice(start, start + itemsPerPage)
 
+  // 1. 현재 화면에 'AI 리포트 분석 중'인 카드가 한 개라도 존재하는지 실시간 체크
+  const hasAnalysingCard = pageRecords.some(
+    (record) =>
+      getReportCardType(record.intvStatus, record.report?.reportStatus) === 'analysingCard',
+  )
+
+  // 2. 분노 클릭 조건 만족 시 실행할 통합 전송 핸들러
+  const handleRageClick = () => {
+    // 분석 중인 카드가 화면에 있을 때만 이벤트를 발송합니다.
+    if (!hasAnalysingCard) return
+
+    // [GA4 전송] - 명세서에 등록한 'rage_click' 이벤트 발송
+    trackEvent('rage_click', {
+      category: 'user_frustration',
+      label: 'ai_report_waiting',
+      screen_name: 'history_page_global',
+    })
+
+    // [MS Clarity 스마트 연동] - 대시보드 커스텀 필터용 타겟팅 이벤트
+    if (typeof window !== 'undefined' && typeof window.clarity === 'function') {
+      window.clarity('event', 'rage_click')
+    }
+  }
+
+  //  3. useRageClick 훅 활용
+  const { handleContainerClick } = useRageClick(handleRageClick)
+
+  // 수정 전:
   if (records.length === 0) {
+    // 수정 후: 목데이터를 기준으로 빈 화면인지 체크하도록 변경
+    // if (pageRecords.length === 0) {
     if (search) {
       return (
         <motion.div

--- a/src/featured/history/components/HistoryContainer.tsx
+++ b/src/featured/history/components/HistoryContainer.tsx
@@ -99,13 +99,13 @@ function FlipCard({ record }: FlipCardProps) {
 
   if (!cardType) return null
 
+  // 카드 상태에 따라 완료 카드는 상세로 이동하고, 분석 중 카드는 rage click 후보로 등록
   const handleCardClick = () => {
     if (isCompleted) {
       router.push(`/report/${record.intvId}`)
       return
     }
 
-    //  분석 중 카드 영역 클릭만 rage click 카운트 등록
     if (isAnalysing) {
       registerRageClick()
     }

--- a/src/featured/history/components/HistoryContainer.tsx
+++ b/src/featured/history/components/HistoryContainer.tsx
@@ -42,47 +42,47 @@ function FlipCard({ record }: FlipCardProps) {
   const isCompleted = cardType === 'completedCard'
   const isAnalysing = cardType === 'analysingCard'
 
-  // 이벤트 payload에서 반복해서 쓸 id 분리
   const reportId = record.report?.reportId
-  const intvId = record.intvId
 
   useEffect(() => {
-    if (cardType === 'analysingCard' && prevCardType.current !== 'analysingCard') {
+    if (cardType === 'analysingCard' && prevCardType.current !== 'analysingCard' && reportId) {
       trackEvent('report_gen_start', {
         category: 'ai_report',
-        report_id: reportId ?? '',
-        intv_id: intvId,
+        report_id: reportId,
       })
 
-      trackEvent('report_waiting_session', {
-        category: 'ai_report',
-        report_id: reportId ?? '',
-        intv_id: intvId,
-        page: 'history',
-        status: 'generating',
-      })
+      const waitingSessionKey = `report_waiting_session:${reportId}`
+
+      if (!sessionStorage.getItem(waitingSessionKey)) {
+        sessionStorage.setItem(waitingSessionKey, 'true')
+
+        trackEvent('report_waiting_session', {
+          category: 'ai_report',
+          report_id: reportId,
+          page: 'history',
+          status: 'generating',
+        })
+      }
     }
 
-    if (prevCardType.current === 'analysingCard' && cardType === 'completedCard') {
+    if (prevCardType.current === 'analysingCard' && cardType === 'completedCard' && reportId) {
       trackEvent('report_gen_complete', {
         category: 'ai_report',
-        report_id: reportId ?? '',
-        intv_id: intvId,
+        report_id: reportId,
       })
     }
 
     prevCardType.current = cardType
-  }, [cardType, reportId, intvId])
+  }, [cardType, reportId])
 
   const handleRageClick = useCallback(() => {
-    if (!isAnalysing) return
+    if (!isAnalysing || !reportId) return
 
     trackEvent(
       'report_waiting_rage_click',
       {
         category: 'user_frustration',
-        report_id: reportId ?? '',
-        intv_id: intvId,
+        report_id: reportId,
         page: 'history',
         status: 'generating',
         click_count: 3,
@@ -90,7 +90,7 @@ function FlipCard({ record }: FlipCardProps) {
       },
       { clarity: true },
     )
-  }, [isAnalysing, reportId, intvId])
+  }, [isAnalysing, reportId])
 
   // useRageClick을 FlipCard 내부로 이동
   // React 훅 규칙상 조건문 안에서 호출하면 안 되므로 항상 호출하고,

--- a/src/featured/history/components/HistoryContainer.tsx
+++ b/src/featured/history/components/HistoryContainer.tsx
@@ -38,7 +38,6 @@ function FlipCard({ record }: FlipCardProps) {
 
   const prevCardType = useRef<string | null>(null)
 
-  // 카드 상태를 boolean으로 분리
   const isCompleted = cardType === 'completedCard'
   const isAnalysing = cardType === 'analysingCard'
 
@@ -92,23 +91,18 @@ function FlipCard({ record }: FlipCardProps) {
     )
   }, [isAnalysing, reportId])
 
-  // useRageClick을 FlipCard 내부로 이동
-  // React 훅 규칙상 조건문 안에서 호출하면 안 되므로 항상 호출하고,
-  // 실제 실행은 handleCardClick에서 isAnalysing일 때만 함
-  const { handleContainerClick } = useRageClick(handleRageClick)
+  const { registerRageClick } = useRageClick(handleRageClick)
 
   if (!cardType) return null
 
-  // 완료 카드 클릭과 분석 중 카드 클릭을 하나의 핸들러에서 분기
   const handleCardClick = () => {
     if (isCompleted) {
       router.push(`/report/${record.intvId}`)
       return
     }
 
-    //  분석 중 카드일 때만 rage click 카운트 증가
     if (isAnalysing) {
-      handleContainerClick()
+      registerRageClick()
     }
   }
 

--- a/src/featured/history/hooks/useRageClick.ts
+++ b/src/featured/history/hooks/useRageClick.ts
@@ -1,15 +1,12 @@
 import { useRef, useEffect, useCallback } from 'react'
 
 interface RageClickOptions {
-  limit?: number;     // 분노 클릭 기준 횟수 (기본값 3)
-  cooldown?: number;  // 초기화 대기 시간 (기본값 2000ms)
+  limit?: number // 분노 클릭 기준 횟수 (기본값 3)
+  windowMs?: number // 몇 ms 안에서 클릭을 묶을지 (기본값 2000ms)
 }
 
-export function useRageClick(
-  onRageClick: () => void, 
-  options: RageClickOptions = {}
-) {
-  const { limit = 3, cooldown = 2000 } = options;
+export function useRageClick(onRageClick: () => void, options: RageClickOptions = {}) {
+  const { limit = 3, windowMs = 2000 } = options
 
   const clickCountRef = useRef(0)
   const timerRef = useRef<NodeJS.Timeout | null>(null)
@@ -37,8 +34,8 @@ export function useRageClick(
 
     timerRef.current = setTimeout(() => {
       clickCountRef.current = 0
-    }, cooldown)
-  }, [onRageClick, limit, cooldown])
+    }, windowMs)
+  }, [onRageClick, limit, windowMs])
 
   // 이제 외부로 굳이 타이머 클리어 함수를 내보내지 않아도 안전합니다!
   return { handleContainerClick }

--- a/src/featured/history/hooks/useRageClick.ts
+++ b/src/featured/history/hooks/useRageClick.ts
@@ -18,8 +18,7 @@ export function useRageClick(onRageClick: () => void, options: RageClickOptions 
     }
   }, [])
 
-  // 2. 외부에서 사용할 클릭 핸들러 (useCallback으로 최적화)
-  const handleContainerClick = useCallback(() => {
+  const registerRageClick = useCallback(() => {
     clickCountRef.current += 1
 
     if (timerRef.current) {
@@ -38,5 +37,5 @@ export function useRageClick(onRageClick: () => void, options: RageClickOptions 
   }, [onRageClick, limit, windowMs])
 
   // 이제 외부로 굳이 타이머 클리어 함수를 내보내지 않아도 안전합니다!
-  return { handleContainerClick }
+  return { registerRageClick }
 }

--- a/src/shared/lib/utils/analytics.ts
+++ b/src/shared/lib/utils/analytics.ts
@@ -62,7 +62,10 @@ export const trackClarityEvent = (eventName: FunnelStep | string) => {
   if (!isBrowser() || typeof window.clarity !== 'function') return
 
   clarity.event(eventName)
-  logAnalyticsEvent('Clarity', eventName)
+
+  if (process.env.NODE_ENV === 'development') {
+    console.info('[Clarity:sent]', eventName)
+  }
 }
 
 export const trackEvent = (

--- a/src/shared/lib/utils/analytics.ts
+++ b/src/shared/lib/utils/analytics.ts
@@ -1,5 +1,4 @@
 import { sendGAEvent } from '@next/third-parties/google'
-import clarity from '@microsoft/clarity'
 
 declare global {
   interface Window {
@@ -61,7 +60,7 @@ const logAnalyticsEvent = (
 export const trackClarityEvent = (eventName: FunnelStep | string) => {
   if (!isBrowser() || typeof window.clarity !== 'function') return
 
-  clarity.event(eventName)
+  window.clarity('event', eventName)
 
   if (process.env.NODE_ENV === 'development') {
     console.info('[Clarity:sent]', eventName)

--- a/src/shared/lib/utils/analytics.ts
+++ b/src/shared/lib/utils/analytics.ts
@@ -8,7 +8,8 @@ type FunnelStep =
   | 'report_gen_start' // 리포트 생성 시작
   | 'report_gen_complete' // 리포트 생성 완료
   | 'loading_tab_leave' // 리포트 발행 로딩 중 탭 이탈
-  | 'rage_click' // 분노의 클릭
+  | 'report_waiting_session' // 리포트 생성 대기 중 전체 세션
+  | 'report_waiting_rage_click' // 리포트 생성 대기 중 분노의 클릭
 
   // 2. 파일 업로드 및 면접 시작 플로우 점검
   | 'open_interview_modal' // 모달창 최초 진입 (1단계)

--- a/src/shared/lib/utils/analytics.ts
+++ b/src/shared/lib/utils/analytics.ts
@@ -1,4 +1,11 @@
 import { sendGAEvent } from '@next/third-parties/google'
+import clarity from '@microsoft/clarity'
+
+declare global {
+  interface Window {
+    clarity?: (...args: unknown[]) => void
+  }
+}
 
 // 기획 단계에서 정의한 이벤트 명세
 type FunnelStep =
@@ -32,6 +39,29 @@ type FunnelStep =
 type EventParams = Record<string, string | number | boolean> & {
   question_number?: number
   category?: string
+}
+
+interface TrackEventOptions {
+  clarity?: boolean
+}
+
+const isBrowser = () => typeof window !== 'undefined'
+
+const logAnalyticsEvent = (
+  destination: 'GA4' | 'Clarity',
+  eventName: FunnelStep | string,
+  params?: EventParams,
+) => {
+  if (process.env.NODE_ENV !== 'development') return
+
+  console.info(`[${destination}] event: ${eventName}`, params || {})
+}
+
+export const trackClarityEvent = (eventName: FunnelStep | string) => {
+  if (!isBrowser() || typeof window.clarity !== 'function') return
+
+  clarity.event(eventName)
+  logAnalyticsEvent('Clarity', eventName)
 }
 
 // string 대신 FunnelStep 타입을 적용

--- a/src/shared/lib/utils/analytics.ts
+++ b/src/shared/lib/utils/analytics.ts
@@ -54,6 +54,7 @@ const logAnalyticsEvent = (
 ) => {
   if (process.env.NODE_ENV !== 'development') return
 
+  // 개발 환경에서는 콘솔에 이벤트 로깅 (GA4와 Clarity 구분)
   console.info(`[${destination}] event: ${eventName}`, params || {})
 }
 
@@ -64,10 +65,18 @@ export const trackClarityEvent = (eventName: FunnelStep | string) => {
   logAnalyticsEvent('Clarity', eventName)
 }
 
-// string 대신 FunnelStep 타입을 적용
-export const trackEvent = (eventName: FunnelStep | string, params?: EventParams) => {
+export const trackEvent = (
+  eventName: FunnelStep | string,
+  params?: EventParams,
+  options?: TrackEventOptions,
+) => {
   const isDev = process.env.NODE_ENV === 'development'
   sendGAEvent('event', eventName, { ...(params || {}), ...(isDev && { debug_mode: true }) })
+  logAnalyticsEvent('GA4', eventName, params)
+
+  if (options?.clarity) {
+    trackClarityEvent(eventName)
+  }
 }
 
 // 퍼널 함수에는 더 엄격하게 FunnelStep 타입만 허용


### PR DESCRIPTION
## 변경 사항

- `analytics.ts`에 AI 리포트 대기 관련 이벤트를 추가했습니다.
    - `report_waiting_session`
    - `report_waiting_rage_click`
- `trackEvent`에 Clarity 전송 옵션을 추가해 특정 이벤트를 GA4와 Clarity에 함께 전송할 수 있도록 수정
- `useRageClick.ts`에서 클릭 감지 기준명을 `cool_down`에서 `window_ms` 기준으로 정리
- `HistoryContainer.tsx`에서 grid 전체 클릭 감지를 제거하고, `FlipCard` 내부의 `analysingCard` 상태에서만 rage click을 감지하도록 수정
- `report_id` 기준으로 리포트 대기 세션을 식별하도록 정리

## 리뷰 필요

- `analytics.ts`
- `useRageClick.ts`
- `HistoryContainer.tsx`
- `layout.tsx`

close #57 
