### PR TITLE
refactor : 로컬 개발환경 Clarity 전송 차단

### DIFF
--- a/src/shared/lib/ClarityProvider.tsx
+++ b/src/shared/lib/ClarityProvider.tsx
@@ -8,7 +8,9 @@ interface ClarityProviderProps {
 }
 export default function ClarityProvider({ clarityId }: ClarityProviderProps) {
   useEffect(() => {
+    if (process.env.NODE_ENV === 'development') return
     if (!clarityId) return
+
     clarity.init(clarityId)
   }, [clarityId])
 

--- a/src/shared/lib/utils/analytics.ts
+++ b/src/shared/lib/utils/analytics.ts
@@ -45,12 +45,16 @@ const isDev = process.env.NODE_ENV === 'development'
 export const trackClarityEvent = (eventName: FunnelStep | string) => {
   if (!isBrowser()) return
 
+  if (isDev) {
+    console.info(`[Clarity-DEV-SKIP] event: ${eventName}`)
+    return
+  }
+
   try {
     clarity.event(eventName)
   } catch (error) {
-    if (isDev) console.warn('[Clarity] event failed:', eventName, error)
+    console.warn('[Clarity] event failed:', eventName, error)
   }
-  if (isDev) console.info(`[Clarity] event: ${eventName}`)
 }
 
 export const trackEvent = (


### PR DESCRIPTION
## 변경 사항

- 로컬 개발환경에서 Clarity 초기화(`clarity.init`) 차단
- 로컬 개발환경에서 Clarity 이벤트 전송(`clarity.event`) 차단 및 `[Clarity-DEV-SKIP]` 로그 출력

## 리뷰 필요
- 로컬에서 `report_waiting_rage_click` 발생 시 Clarity 실제 전송 없이 콘솔 로그만 출력되는지 확인

close #79 