### PR TITLE
feat: 대시보드 이어하기 api 연결 및 구현

### DIFF
--- a/src/app/(authenticated)/(sidebar)/dashboard/page.tsx
+++ b/src/app/(authenticated)/(sidebar)/dashboard/page.tsx
@@ -12,7 +12,7 @@ export default async function DashboardPage() {
     <>
       <DashboardHeader />
       <div className="space-y-6 px-8 py-4">
-        <QuickStartSection />
+        <QuickStartSection records={initialRecords} />
         <DashboardLiveSection initialRecords={initialRecords} />
       </div>
     </>

--- a/src/app/(authenticated)/(sidebar)/dashboard/page.tsx
+++ b/src/app/(authenticated)/(sidebar)/dashboard/page.tsx
@@ -2,10 +2,10 @@
 import { DashboardHeader } from '@/featured/dashboard/components/DashboardHeader'
 import { QuickStartSection } from '@/featured/dashboard/components/QuickStartSection'
 import { DashboardLiveSection } from '@/featured/dashboard/components/DashboardLiveSection'
-import { getReportListAction } from '@/featured/history/actions/history.action'
+import { getIntvListAction } from '@/featured/history/actions/history.action'
 
 export default async function DashboardPage() {
-  const response = await getReportListAction()
+  const response = await getIntvListAction()
   const initialRecords = response.success && response.data ? response.data : []
 
   return (

--- a/src/app/(authenticated)/(sidebar)/layout.tsx
+++ b/src/app/(authenticated)/(sidebar)/layout.tsx
@@ -1,9 +1,13 @@
 import { DashboardSidebar } from '@/shared/components/dashboard-sidebar'
+import { getIntvList } from '@/featured/history/services/history.service'
 
-export default function WithSidebarLayout({ children }: { children: React.ReactNode }) {
+export default async function WithSidebarLayout({ children }: { children: React.ReactNode }) {
+  const response = await getIntvList()
+  const pausedRecords = response.data?.filter((r) => r.intvStatus === 'PAUSED') ?? []
+
   return (
     <div className="bg-muted/20 flex h-screen overflow-hidden">
-      <DashboardSidebar />
+      <DashboardSidebar pausedRecords={pausedRecords} />
       <main className="flex flex-1 flex-col overflow-y-auto">{children}</main>
     </div>
   )

--- a/src/featured/dashboard/components/DashboardLiveSection.tsx
+++ b/src/featured/dashboard/components/DashboardLiveSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useReportListQuery } from '@/featured/history/hooks/useReportListQuery'
+import { useIntvListQuery } from '@/featured/history/hooks/useIntvListQuery'
 import { InterviewReportItem } from '@/featured/history/types'
 import { StatusSection } from './StatusSection'
 import { RecentHistorySection } from './RecentHistorySection'
@@ -11,7 +11,7 @@ interface DashboardLiveSectionProps {
 }
 
 export function DashboardLiveSection({ initialRecords }: DashboardLiveSectionProps) {
-  const { data: records = initialRecords } = useReportListQuery()
+  const { data: records = initialRecords } = useIntvListQuery()
 
   return (
     <>

--- a/src/featured/dashboard/components/DeletePausedInterviewModal.tsx
+++ b/src/featured/dashboard/components/DeletePausedInterviewModal.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { RotateCw, Trash2 } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/shared/ui/dialog'
+import { Button } from '@/shared/ui/button'
+import { InterviewReportItem } from '@/featured/history/types'
+
+interface DeletePausedInterviewModalProps {
+  open: boolean
+  onClose: () => void
+  pausedRecords: InterviewReportItem[]
+  onDelete: (intvId: number) => void
+}
+
+export function DeletePausedInterviewModal({
+  open,
+  onClose,
+  pausedRecords,
+  onDelete,
+}: DeletePausedInterviewModalProps) {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) onClose()
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>진행 중인 면접 목록</DialogTitle>
+          <DialogDescription>삭제할 면접을 선택하세요.</DialogDescription>
+        </DialogHeader>
+        <ul className="flex flex-col gap-2 py-1">
+          {pausedRecords.map((record) => (
+            <li
+              key={record.intvId}
+              className="border-border/50 flex items-center gap-3 rounded-lg border p-3"
+            >
+              <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-green-50">
+                <RotateCw className="h-3.5 w-3.5 text-green-600" />
+              </div>
+              <span className="flex-1 truncate text-sm font-medium">{record.title}</span>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={`${record.title} 삭제`}
+                className="text-muted-foreground hover:text-destructive h-8 w-8 shrink-0 cursor-pointer"
+                onClick={() => onDelete(record.intvId)}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/featured/dashboard/components/InterviewStartGuideModal.tsx
+++ b/src/featured/dashboard/components/InterviewStartGuideModal.tsx
@@ -1,65 +1,115 @@
 'use client'
 
+import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Play, RotateCw } from 'lucide-react'
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DialogDescription,
 } from '@/shared/ui/dialog'
 import { Button } from '@/shared/ui/button'
+import { InterviewReportItem } from '@/featured/history/types'
+import { DeletePausedInterviewModal } from './DeletePausedInterviewModal'
+
+const MAX_PAUSED_COUNT = 5
 
 interface InterviewStartGuideModalProps {
   open: boolean
   onClose: () => void
   onResume: () => void
+  pausedRecords: InterviewReportItem[]
 }
 
 export function InterviewStartGuideModal({
   open,
   onClose,
   onResume,
+  pausedRecords,
 }: InterviewStartGuideModalProps) {
   const router = useRouter()
+  const [deletedIds, setDeletedIds] = useState<Set<number>>(new Set())
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+
+  const visibleRecords = pausedRecords.filter((r) => !deletedIds.has(r.intvId))
+  const isMaxPaused = visibleRecords.length >= MAX_PAUSED_COUNT
+
+  const handleClose = () => {
+    setDeletedIds(new Set())
+    setIsDeleteModalOpen(false)
+    onClose()
+  }
+
+  const handleDelete = (intvId: number) => {
+    setDeletedIds((prev) => new Set(prev).add(intvId))
+  }
 
   const handleResume = () => {
-    onClose()
+    handleClose()
     setTimeout(onResume, 200)
   }
 
   const handleStartNew = () => {
-    onClose()
+    handleClose()
     router.push('/interview')
   }
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(isOpen) => {
-        if (!isOpen) onClose()
-      }}
-    >
-      <DialogContent className="max-w-md">
-        <DialogHeader>
-          <DialogTitle>진행 중인 면접이 있어요</DialogTitle>
-          <DialogDescription>
-            이어서 진행하시겠어요, 아니면 새로운 면접을 시작하시겠어요?
-          </DialogDescription>
-        </DialogHeader>
-        <DialogFooter>
-          <Button variant="outline" className="cursor-pointer" onClick={handleResume}>
-            <RotateCw className="h-4 w-4" />
-            이어하기
-          </Button>
-          <Button className="cursor-pointer" onClick={handleStartNew}>
-            <Play className="h-4 w-4" />
-            면접 시작
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+    <>
+      <Dialog
+        open={open}
+        onOpenChange={(isOpen) => {
+          if (!isOpen) handleClose()
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>진행 중인 면접이 있어요</DialogTitle>
+            {!isMaxPaused && (
+              <DialogDescription>
+                이어서 진행하시겠어요, 아니면 새로운 면접을 시작하시겠어요?
+              </DialogDescription>
+            )}
+          </DialogHeader>
+
+          {isMaxPaused && (
+            <p className="text-sm text-red-500">
+              진행중인 면접은 최대 {MAX_PAUSED_COUNT}개 까지만 보관 가능합니다. 새로 면접을
+              시작하시려면 진행중인 면접을 삭제 후 시작해주세요.
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" className="cursor-pointer" onClick={handleResume}>
+              <RotateCw className="h-4 w-4" />
+              이어하기
+            </Button>
+            <Button className="cursor-pointer" onClick={handleStartNew} disabled={isMaxPaused}>
+              <Play className="h-4 w-4" />
+              면접 시작
+            </Button>
+            {isMaxPaused && (
+              <Button
+                variant="outline"
+                className="text-destructive border-destructive/30 hover:bg-destructive/5 hover:text-destructive cursor-pointer"
+                onClick={() => setIsDeleteModalOpen(true)}
+              >
+                삭제
+              </Button>
+            )}
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <DeletePausedInterviewModal
+        open={isDeleteModalOpen}
+        onClose={() => setIsDeleteModalOpen(false)}
+        pausedRecords={visibleRecords}
+        onDelete={handleDelete}
+      />
+    </>
   )
 }

--- a/src/featured/dashboard/components/InterviewStartGuideModal.tsx
+++ b/src/featured/dashboard/components/InterviewStartGuideModal.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { Play, RotateCw } from 'lucide-react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/shared/ui/dialog'
+import { Button } from '@/shared/ui/button'
+
+interface InterviewStartGuideModalProps {
+  open: boolean
+  onClose: () => void
+  onResume: () => void
+}
+
+export function InterviewStartGuideModal({
+  open,
+  onClose,
+  onResume,
+}: InterviewStartGuideModalProps) {
+  const router = useRouter()
+
+  const handleResume = () => {
+    onClose()
+    setTimeout(onResume, 200)
+  }
+
+  const handleStartNew = () => {
+    onClose()
+    router.push('/interview')
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) onClose()
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>진행 중인 면접이 있어요</DialogTitle>
+          <DialogDescription>
+            이어서 진행하시겠어요, 아니면 새로운 면접을 시작하시겠어요?
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="outline" className="cursor-pointer" onClick={handleResume}>
+            <RotateCw className="h-4 w-4" />
+            이어하기
+          </Button>
+          <Button className="cursor-pointer" onClick={handleStartNew}>
+            <Play className="h-4 w-4" />
+            면접 시작
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/featured/dashboard/components/QuickStartCard.tsx
+++ b/src/featured/dashboard/components/QuickStartCard.tsx
@@ -16,7 +16,7 @@ export interface QuickStartCardProps {
   hoverBorderStyle?: string
   isRecommended?: boolean
   isDisabled?: boolean
-  onClick?: () => void
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
 }
 
 export function QuickStartCard({

--- a/src/featured/dashboard/components/QuickStartSection.tsx
+++ b/src/featured/dashboard/components/QuickStartSection.tsx
@@ -5,7 +5,9 @@ import { motion } from 'framer-motion'
 import { Play, History, RotateCw, ArrowRight } from 'lucide-react'
 import { QuickStartCard } from '@/featured/dashboard/components/QuickStartCard'
 import { ResumeInterviewModal } from '@/featured/dashboard/components/ResumeInterviewModal'
+import { InterviewStartGuideModal } from '@/featured/dashboard/components/InterviewStartGuideModal'
 import { Card, CardContent } from '@/shared/ui/card'
+import { InterviewReportItem } from '@/featured/history/types'
 
 const fadeUp = {
   hidden: { opacity: 0, y: 16 },
@@ -16,8 +18,22 @@ const fadeUp = {
   }),
 }
 
-export function QuickStartSection() {
+interface QuickStartSectionProps {
+  records: InterviewReportItem[]
+}
+
+export function QuickStartSection({ records }: QuickStartSectionProps) {
   const [isResumeModalOpen, setIsResumeModalOpen] = useState(false)
+  const [isStartGuideModalOpen, setIsStartGuideModalOpen] = useState(false)
+
+  const pausedInterviewCount = records.filter((record) => record.intvStatus === 'PAUSED').length
+  const hasPausedInterview = pausedInterviewCount > 0
+
+  const handleStartClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    if (!hasPausedInterview) return
+    event.preventDefault()
+    setIsStartGuideModalOpen(true)
+  }
 
   return (
     <div>
@@ -41,6 +57,7 @@ export function QuickStartSection() {
             href="/interview"
             buttonText="지금 시작"
             isRecommended={true}
+            onClick={handleStartClick}
           />
         </motion.div>
 
@@ -71,17 +88,47 @@ export function QuickStartSection() {
           custom={3}
           className="flex-1"
         >
-          <div className="h-full w-full cursor-pointer" onClick={() => setIsResumeModalOpen(true)}>
-            <Card className="group border-border/50 flex h-full flex-col transition-all hover:border-green-300 hover:shadow-md hover:shadow-green-600/5">
+          <div
+            className={`h-full w-full ${hasPausedInterview ? 'cursor-pointer' : 'cursor-not-allowed'}`}
+            aria-disabled={!hasPausedInterview}
+            onClick={() => hasPausedInterview && setIsResumeModalOpen(true)}
+          >
+            <Card
+              className={`group flex h-full flex-col transition-all ${
+                hasPausedInterview
+                  ? 'border-border/50 hover:border-green-300 hover:shadow-md hover:shadow-green-600/5'
+                  : 'border-border/50 bg-slate-50'
+              }`}
+            >
               <CardContent className="flex flex-1 flex-col p-5">
-                <div className="mb-4 flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-linear-to-br from-green-100 to-emerald-100 transition-colors group-hover:from-green-200 group-hover:to-emerald-200">
-                  <RotateCw className="h-5 w-5 text-green-600" />
+                <div
+                  className={`mb-4 flex h-11 w-11 shrink-0 items-center justify-center rounded-xl transition-colors ${
+                    hasPausedInterview
+                      ? 'bg-linear-to-br from-green-100 to-emerald-100 group-hover:from-green-200 group-hover:to-emerald-200'
+                      : 'bg-slate-200/50'
+                  }`}
+                >
+                  <RotateCw
+                    className={`h-5 w-5 ${hasPausedInterview ? 'text-green-600' : 'text-slate-400'}`}
+                  />
                 </div>
-                <h3 className="mb-1 font-semibold">이어하기</h3>
-                <p className="text-muted-foreground flex-1 text-xs leading-relaxed">
-                  진행중인 면접이 있습니다. 이어서 진행해 보세요
+                <h3 className={`mb-1 font-semibold ${hasPausedInterview ? '' : 'text-slate-400'}`}>
+                  이어하기
+                </h3>
+                <p
+                  className={`flex-1 text-xs leading-relaxed ${
+                    hasPausedInterview ? 'text-muted-foreground' : 'text-slate-400 opacity-60'
+                  }`}
+                >
+                  {hasPausedInterview
+                    ? `진행중인 면접이 ${pausedInterviewCount}개 있습니다. 이어서 진행해 보세요`
+                    : '진행중인 면접이 없습니다'}
                 </p>
-                <div className="mt-4 flex shrink-0 items-center gap-1 text-xs font-medium text-green-600">
+                <div
+                  className={`mt-4 flex shrink-0 items-center gap-1 text-xs font-medium ${
+                    hasPausedInterview ? 'text-green-600' : 'text-slate-400'
+                  }`}
+                >
                   이어서 면접보기 <ArrowRight className="h-3 w-3" />
                 </div>
               </CardContent>
@@ -91,6 +138,11 @@ export function QuickStartSection() {
       </div>
 
       <ResumeInterviewModal open={isResumeModalOpen} onClose={() => setIsResumeModalOpen(false)} />
+      <InterviewStartGuideModal
+        open={isStartGuideModalOpen}
+        onClose={() => setIsStartGuideModalOpen(false)}
+        onResume={() => setIsResumeModalOpen(true)}
+      />
     </div>
   )
 }

--- a/src/featured/dashboard/components/QuickStartSection.tsx
+++ b/src/featured/dashboard/components/QuickStartSection.tsx
@@ -26,13 +26,15 @@ export function QuickStartSection({ records }: QuickStartSectionProps) {
   const [isResumeModalOpen, setIsResumeModalOpen] = useState(false)
   const [isStartGuideModalOpen, setIsStartGuideModalOpen] = useState(false)
 
-  const pausedInterviewCount = records.filter((record) => record.intvStatus === 'PAUSED').length
+  const pausedRecords = records.filter((record) => record.intvStatus === 'PAUSED')
+  const pausedInterviewCount = pausedRecords.length
   const hasPausedInterview = pausedInterviewCount > 0
 
-  const handleStartClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    if (!hasPausedInterview) return
-    event.preventDefault()
-    setIsStartGuideModalOpen(true)
+  const handleStartClick = (_event: React.MouseEvent<HTMLAnchorElement>) => {
+    // TODO: 삭제 API 구현 후 팝업 활성화
+    // if (!hasPausedInterview) return
+    // _event.preventDefault()
+    // setIsStartGuideModalOpen(true)
   }
 
   return (
@@ -137,11 +139,16 @@ export function QuickStartSection({ records }: QuickStartSectionProps) {
         </motion.div>
       </div>
 
-      <ResumeInterviewModal open={isResumeModalOpen} onClose={() => setIsResumeModalOpen(false)} />
+      <ResumeInterviewModal
+        open={isResumeModalOpen}
+        onClose={() => setIsResumeModalOpen(false)}
+        pausedRecords={pausedRecords}
+      />
       <InterviewStartGuideModal
         open={isStartGuideModalOpen}
         onClose={() => setIsStartGuideModalOpen(false)}
         onResume={() => setIsResumeModalOpen(true)}
+        pausedRecords={pausedRecords}
       />
     </div>
   )

--- a/src/featured/dashboard/components/QuickStartSection.tsx
+++ b/src/featured/dashboard/components/QuickStartSection.tsx
@@ -1,8 +1,11 @@
 'use client'
 
+import { useState } from 'react'
 import { motion } from 'framer-motion'
-import { Play, History, RotateCw } from 'lucide-react'
+import { Play, History, RotateCw, ArrowRight } from 'lucide-react'
 import { QuickStartCard } from '@/featured/dashboard/components/QuickStartCard'
+import { ResumeInterviewModal } from '@/featured/dashboard/components/ResumeInterviewModal'
+import { Card, CardContent } from '@/shared/ui/card'
 
 const fadeUp = {
   hidden: { opacity: 0, y: 16 },
@@ -13,13 +16,8 @@ const fadeUp = {
   }),
 }
 
-interface QuickStartSectionProps {
-  restartIntvId?: number
-}
-
-export function QuickStartSection({ restartIntvId }: QuickStartSectionProps = {}) {
-  // TODO: 실제 유저 상태(진행 중인 면접 여부)에 따라 이 값을 동적으로 설정해야 합니다.
-  const hasInProgressInterview = !!restartIntvId
+export function QuickStartSection() {
+  const [isResumeModalOpen, setIsResumeModalOpen] = useState(false)
 
   return (
     <div>
@@ -73,24 +71,26 @@ export function QuickStartSection({ restartIntvId }: QuickStartSectionProps = {}
           custom={3}
           className="flex-1"
         >
-          <QuickStartCard
-            title="이어하기"
-            description={
-              hasInProgressInterview
-                ? '진행중인 면접이 있습니다. 이어서 진행해 보세요'
-                : '현재 진행 중인 면접이 없습니다.'
-            }
-            icon={RotateCw}
-            iconStyle="bg-linear-to-br from-green-100 to-emerald-100 text-green-600 group-hover:from-green-200 group-hover:to-emerald-200"
-            iconColorStyle="text-green-600"
-            href={restartIntvId ? `/interview?restart=true&id=${restartIntvId}` : '/interview'}
-            buttonText="이어서 면접보기"
-            isDisabled={!hasInProgressInterview}
-            buttonTextStyle="text-green-600"
-            hoverBorderStyle="hover:border-green-300 hover:shadow-green-600/5"
-          />
+          <div className="h-full w-full cursor-pointer" onClick={() => setIsResumeModalOpen(true)}>
+            <Card className="group border-border/50 flex h-full flex-col transition-all hover:border-green-300 hover:shadow-md hover:shadow-green-600/5">
+              <CardContent className="flex flex-1 flex-col p-5">
+                <div className="mb-4 flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-linear-to-br from-green-100 to-emerald-100 transition-colors group-hover:from-green-200 group-hover:to-emerald-200">
+                  <RotateCw className="h-5 w-5 text-green-600" />
+                </div>
+                <h3 className="mb-1 font-semibold">이어하기</h3>
+                <p className="text-muted-foreground flex-1 text-xs leading-relaxed">
+                  진행중인 면접이 있습니다. 이어서 진행해 보세요
+                </p>
+                <div className="mt-4 flex shrink-0 items-center gap-1 text-xs font-medium text-green-600">
+                  이어서 면접보기 <ArrowRight className="h-3 w-3" />
+                </div>
+              </CardContent>
+            </Card>
+          </div>
         </motion.div>
       </div>
+
+      <ResumeInterviewModal open={isResumeModalOpen} onClose={() => setIsResumeModalOpen(false)} />
     </div>
   )
 }

--- a/src/featured/dashboard/components/RecentHistorySection.tsx
+++ b/src/featured/dashboard/components/RecentHistorySection.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { motion } from 'framer-motion'
 import { Card, CardContent } from '@/shared/ui/card'
-import { ChevronRight, Inbox, Loader2 } from 'lucide-react'
+import { ChevronRight, Inbox, Loader2, RotateCw } from 'lucide-react'
 import { InterviewReportItem } from '@/featured/history/types'
 import { formatDateDot } from '@/shared/lib/utils/date'
 import { getScoreConfig } from '@/featured/report/constants'
@@ -32,6 +32,7 @@ export interface RecentHistorySectionProps {
 
 export function RecentHistorySection({ records = [] }: RecentHistorySectionProps) {
   const displayRecords = [...records]
+    .filter((r) => r.intvStatus === 'FINISHED' || r.intvStatus === 'PAUSED')
     .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
     .slice(0, 3)
   const isEmpty = displayRecords.length === 0
@@ -79,20 +80,32 @@ export function RecentHistorySection({ records = [] }: RecentHistorySectionProps
               const reportStatus = item.report?.reportStatus
               const isAnalyzing = reportStatus === 'IN_PROGRESS'
               const hasScore = score !== null && score !== undefined
+              const isPaused = item.intvStatus === 'PAUSED'
 
               return (
                 <Link
                   key={item.intvId}
-                  href={`/report/${item.intvId}`}
-                  className="flex h-18.25 flex-col justify-center"
+                  href={
+                    isPaused
+                      ? `/interview?restart=true&id=${item.intvId}`
+                      : `/report/${item.intvId}`
+                  }
+                  onClick={(e) => { if (isAnalyzing) e.preventDefault() }}
+                  className={`flex h-18.25 flex-col justify-center${isAnalyzing ? ' pointer-events-none opacity-60' : ''}`}
                 >
                   <div className="hover:bg-muted/40 flex h-full w-full items-center gap-4 px-5 transition-colors">
                     <div
                       className={`flex h-10 w-10 shrink-0 flex-col items-center justify-center rounded-xl text-sm font-bold ${
-                        hasScore ? getScoreConfig(score).style : 'bg-slate-100 text-slate-500'
+                        isPaused
+                          ? 'bg-green-50 text-green-600'
+                          : hasScore
+                            ? getScoreConfig(score).style
+                            : 'bg-slate-100 text-slate-500'
                       }`}
                     >
-                      {isAnalyzing ? (
+                      {isPaused ? (
+                        <RotateCw className="h-4 w-4" />
+                      ) : isAnalyzing ? (
                         <Loader2 className="h-4 w-4 animate-spin" />
                       ) : hasScore ? (
                         score
@@ -101,8 +114,10 @@ export function RecentHistorySection({ records = [] }: RecentHistorySectionProps
                       )}
                     </div>
                     <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-medium">{item.intvTitle}</p>
-                      {isAnalyzing ? (
+                      <p className="truncate text-sm font-medium">{item.title}</p>
+                      {isPaused ? (
+                        <p className="text-xs text-green-600">일시정지됨</p>
+                      ) : isAnalyzing ? (
                         <p className="text-xs text-amber-500">AI 리포트 분석 중...</p>
                       ) : (
                         <p className="text-muted-foreground text-xs">

--- a/src/featured/dashboard/components/ResumeInterviewModal.tsx
+++ b/src/featured/dashboard/components/ResumeInterviewModal.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { RotateCw, Clock } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/shared/ui/dialog'
+
+interface PausedInterview {
+  intvId: number
+  intvTitle: string
+  updatedAt: string
+}
+
+const MOCK_PAUSED_INTERVIEWS: PausedInterview[] = [
+  { intvId: 1, intvTitle: '카카오 백엔드 면접', updatedAt: '2026-06-05T14:30:00' },
+  { intvId: 2, intvTitle: '네이버 프론트엔드 면접', updatedAt: '2026-06-04T10:15:00' },
+  { intvId: 3, intvTitle: '토스 풀스택 면접', updatedAt: '2026-06-03T18:00:00' },
+]
+
+function formatDate(dateString: string): string {
+  return new Date(dateString).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+interface ResumeInterviewModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+export function ResumeInterviewModal({ open, onClose }: ResumeInterviewModalProps) {
+  const router = useRouter()
+
+  const handleResume = (intvId: number) => {
+    onClose()
+    router.push(`/interview?restart=true&id=${intvId}`)
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) onClose()
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>이어할 면접 선택</DialogTitle>
+          <DialogDescription>일시 중단된 면접 목록입니다.</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 py-2">
+          {MOCK_PAUSED_INTERVIEWS.map((item) => (
+            <div
+              key={item.intvId}
+              className="border-border/50 hover:bg-muted/30 flex cursor-pointer items-center gap-3 rounded-lg border p-4 transition-colors"
+              onClick={() => handleResume(item.intvId)}
+            >
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-green-50">
+                <RotateCw className="h-4 w-4 text-green-600" />
+              </div>
+              <div>
+                <p className="text-sm font-medium">{item.intvTitle}</p>
+                <p className="text-muted-foreground mt-0.5 flex items-center gap-1 text-xs">
+                  <Clock className="h-3 w-3" />
+                  {formatDate(item.updatedAt)}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/featured/dashboard/components/ResumeInterviewModal.tsx
+++ b/src/featured/dashboard/components/ResumeInterviewModal.tsx
@@ -9,31 +9,16 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/shared/ui/dialog'
-
-interface PausedInterview {
-  intvId: number
-  intvTitle: string
-  updatedAt: string
-}
-
-const pausedInterviews: PausedInterview[] = []
-
-function formatDate(dateString: string): string {
-  return new Date(dateString).toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  })
-}
+import { InterviewReportItem } from '@/featured/history/types'
+import { formatDateTimeKorean } from '@/shared/lib/utils/date'
 
 interface ResumeInterviewModalProps {
   open: boolean
   onClose: () => void
+  pausedRecords: InterviewReportItem[]
 }
 
-export function ResumeInterviewModal({ open, onClose }: ResumeInterviewModalProps) {
+export function ResumeInterviewModal({ open, onClose, pausedRecords }: ResumeInterviewModalProps) {
   const router = useRouter()
 
   const handleResume = (intvId: number) => {
@@ -54,7 +39,7 @@ export function ResumeInterviewModal({ open, onClose }: ResumeInterviewModalProp
           <DialogDescription>일시 중단된 면접 목록입니다.</DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-3 py-2">
-          {pausedInterviews.map((item) => (
+          {pausedRecords.map((item) => (
             <div
               key={item.intvId}
               className="border-border/50 hover:bg-muted/30 flex cursor-pointer items-center gap-3 rounded-lg border p-4 transition-colors"
@@ -64,10 +49,10 @@ export function ResumeInterviewModal({ open, onClose }: ResumeInterviewModalProp
                 <RotateCw className="h-4 w-4 text-green-600" />
               </div>
               <div>
-                <p className="text-sm font-medium">{item.intvTitle}</p>
+                <p className="text-sm font-medium">{item.title}</p>
                 <p className="text-muted-foreground mt-0.5 flex items-center gap-1 text-xs">
                   <Clock className="h-3 w-3" />
-                  {formatDate(item.updatedAt)}
+                  {formatDateTimeKorean(item.updatedAt)}
                 </p>
               </div>
             </div>

--- a/src/featured/dashboard/components/ResumeInterviewModal.tsx
+++ b/src/featured/dashboard/components/ResumeInterviewModal.tsx
@@ -16,11 +16,7 @@ interface PausedInterview {
   updatedAt: string
 }
 
-const MOCK_PAUSED_INTERVIEWS: PausedInterview[] = [
-  { intvId: 1, intvTitle: '카카오 백엔드 면접', updatedAt: '2026-06-05T14:30:00' },
-  { intvId: 2, intvTitle: '네이버 프론트엔드 면접', updatedAt: '2026-06-04T10:15:00' },
-  { intvId: 3, intvTitle: '토스 풀스택 면접', updatedAt: '2026-06-03T18:00:00' },
-]
+const pausedInterviews: PausedInterview[] = []
 
 function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleDateString('ko-KR', {
@@ -58,7 +54,7 @@ export function ResumeInterviewModal({ open, onClose }: ResumeInterviewModalProp
           <DialogDescription>일시 중단된 면접 목록입니다.</DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-3 py-2">
-          {MOCK_PAUSED_INTERVIEWS.map((item) => (
+          {pausedInterviews.map((item) => (
             <div
               key={item.intvId}
               className="border-border/50 hover:bg-muted/30 flex cursor-pointer items-center gap-3 rounded-lg border p-4 transition-colors"

--- a/src/featured/dashboard/components/ScoreTrendChart.tsx
+++ b/src/featured/dashboard/components/ScoreTrendChart.tsx
@@ -43,7 +43,7 @@ export function ScoreTrendChart({ weekStart, weekEnd, records }: ScoreTrendChart
       .map((r) => ({
         name: '', // 아래 map에서 회차로 채워짐
         score: r.report?.totalScore || 0,
-        position: r.intvTitle,
+        position: r.title,
         dateObj: new Date(r.updatedAt),
       }))
       .filter((s) => s.dateObj >= weekStart && s.dateObj <= weekEnd)

--- a/src/featured/history/actions/history.action.ts
+++ b/src/featured/history/actions/history.action.ts
@@ -3,9 +3,8 @@
 import type { ApiResponse } from '@/shared/lib/api'
 import { withAction } from '@/shared/lib/withAction'
 import { InterviewReportItem } from '../types'
-import { getReportList } from '../services/history.service'
+import { getIntvList } from '../services/history.service'
 
-// 리포트 목록 (면접 기록) 조회
-export async function getReportListAction(): Promise<ApiResponse<InterviewReportItem[]>> {
-  return withAction(() => getReportList())
+export async function getIntvListAction(): Promise<ApiResponse<InterviewReportItem[]>> {
+  return withAction(() => getIntvList())
 }

--- a/src/featured/history/components/HistoryContainer.tsx
+++ b/src/featured/history/components/HistoryContainer.tsx
@@ -130,7 +130,9 @@ function FlipCard({ record }: FlipCardProps) {
       <CardContainer isHovered={isHovered}>
         <Card className="absolute inset-0 flex flex-col overflow-hidden backface-hidden">
           {cardType === 'completedCard' && <CompletedCardFront record={record} />}
-          {cardType === 'pendingCard' && <PendingCard intvId={record.intvId} />}
+          {cardType === 'pendingCard' && (
+            <PendingCard intvId={record.intvId} title={record.title} />
+          )}
           {cardType === 'analysingCard' && <AnalysingCard />}
           {cardType === 'failedCard' && <FailedCard record={record} />}
         </Card>

--- a/src/featured/history/components/HistoryLayout.tsx
+++ b/src/featured/history/components/HistoryLayout.tsx
@@ -3,14 +3,14 @@
 import { useState } from 'react'
 import { SortBy } from '@/featured/history/types'
 import { useHistoryFilter } from '@/featured/history/hooks/useHistoryFilter'
-import { useReportListQuery } from '@/featured/history/hooks/useReportListQuery'
+import { useIntvListQuery } from '@/featured/history/hooks/useIntvListQuery'
 import { HistoryFilterBar } from '@/featured/history/components/HistoryFilterBar'
 import { HistoryContainer } from '@/featured/history/components/HistoryContainer'
 import { HistoryPagination } from '@/featured/history/components/HistoryPagination'
 import { useColumnsPerRow } from '@/featured/history/hooks/useColumnsPerRow'
 
 export function HistoryLayout() {
-  const { data: records = [] } = useReportListQuery()
+  const { data: records = [] } = useIntvListQuery()
   const { search, setSearch, sortBy, setSortBy, filtered } = useHistoryFilter(records)
   const cols = useColumnsPerRow()
   const [currentPage, setCurrentPage] = useState(1)

--- a/src/featured/history/components/cards/CompletedCard.tsx
+++ b/src/featured/history/components/cards/CompletedCard.tsx
@@ -31,7 +31,7 @@ function CompletedCardFront({ record }: CompletedCardProps) {
           <div>
             {/* 수정 부분: 높이(h)를 고정하여 1줄일 때나 2줄일 때나 레이아웃이 동일하게 유지되도록 설정, 2줄 이상은 말줄임 처리 */}
             <h3 className="mb-0.5 line-clamp-2 h-[2.5em] text-[11px] leading-tight font-bold text-gray-900 @[180px]:text-xs @[220px]:text-sm @[280px]:mb-1 @[280px]:text-base">
-              {record.intvTitle}
+              {record.title}
             </h3>
             <p className="text-[9px] text-gray-500 @[180px]:text-[10px] @[220px]:text-xs">
               {record.report?.answeredCount}개 질문
@@ -44,7 +44,7 @@ function CompletedCardFront({ record }: CompletedCardProps) {
             </div>
             <div className="flex items-center gap-1 text-[10px] text-gray-600 @[180px]:gap-1.5 @[180px]:text-[11px] @[220px]:gap-2 @[220px]:text-xs @[280px]:text-sm">
               <Clock className="h-2.5 w-2.5 shrink-0 text-blue-500 @[180px]:h-3 @[180px]:w-3 @[220px]:h-3.5 @[220px]:w-3.5 @[280px]:h-4 @[280px]:w-4" />
-              <span>{formatDuration(record.durationMs)}</span>
+              <span>{formatDuration(record.durationSeconds)}</span>
             </div>
           </div>
         </div>
@@ -70,7 +70,7 @@ function CompletedCardBack({ record }: CompletedCardProps) {
               잘한 점
             </p>
           </div>
-          <ul className="overflow-hidden space-y-0.5 @[180px]:space-y-1 @[220px]:space-y-1.5">
+          <ul className="space-y-0.5 overflow-hidden @[180px]:space-y-1 @[220px]:space-y-1.5">
             {strengths.length > 0 ? (
               strengths.map((strength: string, idx: number) => (
                 <li key={idx} className="flex items-start gap-1 @[180px]:gap-1.5">
@@ -97,7 +97,7 @@ function CompletedCardBack({ record }: CompletedCardProps) {
               개선점
             </p>
           </div>
-          <ul className="overflow-hidden space-y-0.5 @[180px]:space-y-1 @[220px]:space-y-1.5">
+          <ul className="space-y-0.5 overflow-hidden @[180px]:space-y-1 @[220px]:space-y-1.5">
             {weaknesses.length > 0 ? (
               weaknesses.map((weakness: string, idx: number) => (
                 <li key={idx} className="flex items-start gap-1 @[180px]:gap-1.5">

--- a/src/featured/history/components/cards/FailedCard.tsx
+++ b/src/featured/history/components/cards/FailedCard.tsx
@@ -30,7 +30,7 @@ export function FailedCard({ record }: FailedCardProps) {
           <div>
             {/* 수정 부분: CompletedCard와 동일하게 라인 클램프 및 높이 고정 적용 */}
             <h3 className="mb-0.5 line-clamp-2 h-[2.5em] text-[11px] leading-tight font-bold text-gray-900 @[180px]:text-xs @[220px]:text-sm @[280px]:mb-1 @[280px]:text-base">
-              {record.intvTitle}
+              {record.title}
             </h3>
           </div>
 

--- a/src/featured/history/components/cards/PendingCard.tsx
+++ b/src/featured/history/components/cards/PendingCard.tsx
@@ -1,28 +1,40 @@
 import Link from 'next/link'
+import { motion } from 'framer-motion'
 import { RotateCw } from 'lucide-react'
 
 interface PendingCardProps {
   intvId: number
+  title: string
 }
 
-export function PendingCard({ intvId }: PendingCardProps) {
+export function PendingCard({ intvId, title }: PendingCardProps) {
   return (
-    <Link
-      href={`/interview?restart=true&id=${intvId}`}
-      onClick={(e) => e.stopPropagation()}
-      className="flex h-full flex-col items-center justify-center gap-2 p-3 text-center @[180px]:gap-3 @[180px]:p-4 @[220px]:gap-4 @[220px]:p-5 @[280px]:gap-6 @[280px]:p-6"
-    >
-      <div className="rounded-full bg-linear-to-br from-green-100 to-emerald-100 p-3 @[180px]:p-4 @[220px]:p-5 @[280px]:p-6">
-        <RotateCw className="h-6 w-6 text-green-600 @[180px]:h-8 @[180px]:w-8 @[220px]:h-10 @[220px]:w-10 @[280px]:h-12 @[280px]:w-12" />
-      </div>
-      <div>
-        <h3 className="mb-0.5 text-xs font-bold text-gray-900 @[180px]:mb-1 @[180px]:text-sm @[220px]:text-base @[280px]:text-xl">
-          이어하기
-        </h3>
-        <p className="text-[9px] text-gray-500 @[180px]:text-[10px] @[220px]:text-xs @[280px]:text-sm">
-          중단된 면접을 계속 진행하세요
-        </p>
-      </div>
-    </Link>
+    <motion.div whileHover="hover" className="h-full">
+      <Link
+        href={`/interview?restart=true&id=${intvId}`}
+        onClick={(e) => e.stopPropagation()}
+        className="flex h-full flex-col items-center justify-center gap-2 p-3 text-center @[180px]:gap-3 @[180px]:p-4 @[220px]:gap-4 @[220px]:p-5 @[280px]:gap-6 @[280px]:p-6"
+      >
+        <div className="rounded-full bg-linear-to-br from-green-100 to-emerald-100 p-3 @[180px]:p-4 @[220px]:p-5 @[280px]:p-6">
+          <motion.div
+            variants={{ hover: { rotate: 360 } }}
+            transition={{ duration: 0.5, ease: 'easeInOut' }}
+          >
+            <RotateCw className="h-6 w-6 text-green-600 @[180px]:h-8 @[180px]:w-8 @[220px]:h-10 @[220px]:w-10 @[280px]:h-12 @[280px]:w-12" />
+          </motion.div>
+        </div>
+        <div>
+          <p className="mb-0.5 line-clamp-1 text-[9px] font-medium text-gray-400 @[180px]:text-[10px] @[220px]:text-xs @[280px]:text-sm">
+            {title}
+          </p>
+          <h3 className="mb-0.5 text-xs font-bold text-gray-900 @[180px]:mb-1 @[180px]:text-sm @[220px]:text-base @[280px]:text-xl">
+            이어하기
+          </h3>
+          <p className="text-[9px] text-gray-500 @[180px]:text-[10px] @[220px]:text-xs @[280px]:text-sm">
+            중단된 면접을 계속 진행하세요
+          </p>
+        </div>
+      </Link>
+    </motion.div>
   )
 }

--- a/src/featured/history/hooks/useHistoryFilter.ts
+++ b/src/featured/history/hooks/useHistoryFilter.ts
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react'
 import type { SortBy, InterviewReportItem } from '../types'
+import { getReportCardType } from '../constants'
 
 export function useHistoryFilter(records: InterviewReportItem[] = []) {
   const [search, setSearch] = useState('')
@@ -9,11 +10,13 @@ export function useHistoryFilter(records: InterviewReportItem[] = []) {
   const filtered = useMemo(() => {
     return records
       .filter((record) => {
+        const cardType = getReportCardType(record.intvStatus, record.report?.reportStatus)
+        if (!cardType) return false
+
         // 검색어가 없으면 모두 보여줌
         if (!search) return true
 
-        // 1. 기존 position -> intvTitle (대소문자 구분 없이 검색되도록 toLowerCase 추가)
-        return record.intvTitle.toLowerCase().includes(search.toLowerCase())
+        return record.title.toLowerCase().includes(search.toLowerCase())
       })
       .sort((a, b) => {
         // 2. 기존 score -> report.totalScore

--- a/src/featured/history/hooks/useIntvListQuery.ts
+++ b/src/featured/history/hooks/useIntvListQuery.ts
@@ -2,18 +2,18 @@
 
 import { useQuery } from '@tanstack/react-query'
 import { useAuthStore } from '@/featured/auth/store'
-import { getReportListAction } from '@/featured/history/actions/history.action'
+import { getIntvListAction } from '@/featured/history/actions/history.action'
 
 const POLLING_INTERVAL_MS = 30000
 
-export function useReportListQuery() {
+export function useIntvListQuery() {
   const { isLoggedIn } = useAuthStore()
 
   return useQuery({
-    queryKey: ['reportList'],
+    queryKey: ['intvList'],
     queryFn: async () => {
-      const response = await getReportListAction()
-      if (!response.success) throw new Error('리포트 목록 조회 실패')
+      const response = await getIntvListAction()
+      if (!response.success) throw new Error('면접 목록 조회 실패')
       return response.data ?? []
     },
     enabled: isLoggedIn,

--- a/src/featured/history/services/history.service.ts
+++ b/src/featured/history/services/history.service.ts
@@ -1,14 +1,14 @@
-import { ApiResponse, serverApi } from '@/shared/lib/api'
+import { ApiResponse, PaginatedResponse, serverApi } from '@/shared/lib/api'
 import { InterviewReportItem } from '../types'
 
-
-/**
- * 리포트 목록을 조회합니다.
- * GET /api/v1/report/list (토큰을 통해 자동으로 유저 식별)
- */
-export async function getReportList(): Promise<ApiResponse<InterviewReportItem[]>> {
-  // 이제 userId 파라미터가 필요 없으므로 silent 옵션만 남깁니다.
-  const config = { silent: true }
-
-  return await serverApi.get<InterviewReportItem[]>('/api/v1/report/list', config)
+export async function getIntvList(): Promise<ApiResponse<InterviewReportItem[]>> {
+  const config = { silent: true, params: { size: 200 } }
+  const response = await serverApi.get<PaginatedResponse<InterviewReportItem>>(
+    '/api/v1/intvs',
+    config,
+  )
+  return {
+    ...response,
+    data: response.data?.content ?? null,
+  }
 }

--- a/src/featured/history/types.ts
+++ b/src/featured/history/types.ts
@@ -12,9 +12,10 @@ export interface ReportSummary {
 
 export interface InterviewReportItem {
   intvId: number
-  intvTitle: string
+  title: string
   intvStatus: 'READY' | 'FINISHED' | 'PAUSED' | 'IN_PROGRESS'
-  durationMs: number | null
+  durationSeconds: number | null
+  createdAt: string
   updatedAt: string
   report: ReportSummary | null
 }

--- a/src/featured/report/components/ScoreSummaryCard.tsx
+++ b/src/featured/report/components/ScoreSummaryCard.tsx
@@ -7,7 +7,7 @@ import { Separator } from '@/shared/ui/separator'
 import { Award, Clock, MessageSquare, ShieldCheck } from 'lucide-react'
 import type { AiConfidenceLevel } from '@/featured/report/types'
 import { getScoreConfig, AI_CONFIDENCE_STYLE } from '@/featured/report/constants'
-import { formatDuration } from '@/shared/lib/utils/date'
+import { formatDurationMs } from '@/shared/lib/utils/date'
 
 interface ScoreSummaryCardProps {
   overallScore: number
@@ -99,7 +99,7 @@ export function ScoreSummaryCard({
               <Clock className="h-4 w-4" />
               평균 답변 시간
             </span>
-            <span className="font-medium">{formatDuration(avgAnswerDurationMs)}</span>
+            <span className="font-medium">{formatDurationMs(avgAnswerDurationMs)}</span>
           </div>
           <div className="flex items-center justify-between text-sm">
             <span className="text-muted-foreground flex items-center gap-2">

--- a/src/shared/components/dashboard-sidebar.tsx
+++ b/src/shared/components/dashboard-sidebar.tsx
@@ -15,6 +15,9 @@ import {
   LayoutDashboard,
   Video,
 } from 'lucide-react'
+import { InterviewStartGuideModal } from '@/featured/dashboard/components/InterviewStartGuideModal'
+import { ResumeInterviewModal } from '@/featured/dashboard/components/ResumeInterviewModal'
+import { InterviewReportItem } from '@/featured/history/types'
 
 const navItems = [
   { icon: House, label: '가면 AI', href: '/' },
@@ -24,9 +27,24 @@ const navItems = [
   { icon: ClipboardList, label: '면접 기록', href: '/history' },
 ]
 
-export function DashboardSidebar() {
+interface DashboardSidebarProps {
+  pausedRecords: InterviewReportItem[]
+}
+
+export function DashboardSidebar({ pausedRecords }: DashboardSidebarProps) {
   const [collapsed, setCollapsed] = useState(false)
+  const [isStartGuideModalOpen, setIsStartGuideModalOpen] = useState(false)
+  const [isResumeModalOpen, setIsResumeModalOpen] = useState(false)
   const pathname = usePathname()
+
+  const hasPausedInterview = pausedRecords.length > 0
+
+  const handleInterviewClick = (_event: React.MouseEvent<HTMLAnchorElement>) => {
+    // TODO: 삭제 API 구현 후 팝업 활성화
+    // if (!hasPausedInterview) return
+    // _event.preventDefault()
+    // setIsStartGuideModalOpen(true)
+  }
 
   return (
     <div className="relative shrink-0">
@@ -72,10 +90,12 @@ export function DashboardSidebar() {
         <nav className="flex-1 space-y-0.5 px-2 py-3">
           {navItems.map((item) => {
             const active = pathname === item.href
+            const isInterviewItem = item.href === '/interview'
 
             const linkEl = (
               <Link
                 href={item.href}
+                onClick={isInterviewItem ? handleInterviewClick : undefined}
                 className={`flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors ${
                   active
                     ? 'bg-primary/10 text-primary'
@@ -123,6 +143,18 @@ export function DashboardSidebar() {
       >
         {collapsed ? <ChevronRight className="h-3 w-3" /> : <ChevronLeft className="h-3 w-3" />}
       </button>
+
+      <InterviewStartGuideModal
+        open={isStartGuideModalOpen}
+        onClose={() => setIsStartGuideModalOpen(false)}
+        onResume={() => setIsResumeModalOpen(true)}
+        pausedRecords={pausedRecords}
+      />
+      <ResumeInterviewModal
+        open={isResumeModalOpen}
+        onClose={() => setIsResumeModalOpen(false)}
+        pausedRecords={pausedRecords}
+      />
     </div>
   )
 }

--- a/src/shared/lib/api/index.ts
+++ b/src/shared/lib/api/index.ts
@@ -1,3 +1,9 @@
 export { clientApi } from './clientApi'
 export { serverApi } from './serverApi'
-export type { NetworkError, ApiResponse, ApiFieldError, RequestConfig } from './types'
+export type {
+  NetworkError,
+  ApiResponse,
+  ApiFieldError,
+  RequestConfig,
+  PaginatedResponse,
+} from './types'

--- a/src/shared/lib/api/types.ts
+++ b/src/shared/lib/api/types.ts
@@ -14,11 +14,11 @@ export class NetworkError extends Error {
 
 /** 서버 공통 응답 래퍼 */
 export interface ApiResponse<T> {
-  success: boolean 
-  code: string 
-  message: string 
-  data: T | null 
-  errors?: ApiFieldError[] | null 
+  success: boolean
+  code: string
+  message: string
+  data: T | null
+  errors?: ApiFieldError[] | null
 }
 
 export interface RequestConfig {
@@ -27,4 +27,12 @@ export interface RequestConfig {
   headers?: Record<string, string>
   cache?: RequestCache
   next?: NextFetchRequestConfig
+}
+
+export interface PaginatedResponse<T> {
+  content: T[]
+  page: number
+  size: number
+  totalElements: number
+  totalPages: number
 }

--- a/src/shared/lib/utils/date.ts
+++ b/src/shared/lib/utils/date.ts
@@ -66,19 +66,37 @@ export const checkIsRecent = (dateString: string): boolean => {
 }
 
 /**
- * 밀리초(ms)를 "M분 S초" 또는 "M분" 형식으로 변환합니다.
- * @param ms 밀리초 단위 숫자
- * @returns 예: 850000 -> "14분 10초", 60000 -> "1분"
+ * 초(seconds)를 "M분 S초" 또는 "M분" 형식으로 변환합니다.
+ * @param seconds 초 단위 숫자
+ * @returns 예: 850 -> "14분 10초", 60 -> "1분"
  */
-export const formatDuration = (ms: number | null): string => {
-  if (!ms) return '0분'
+/**
+ * ISO 날짜 문자열을 "YYYY년 M월 D일 HH:MM" 형식으로 변환합니다.
+ * @param dateString ISO 형식의 날짜 문자열
+ * @returns 예: "2026년 6월 12일 오전 10:30"
+ */
+export const formatDateTimeKorean = (dateString: string): string => {
+  return new Date(dateString).toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
 
-  const totalSeconds = Math.floor(ms / 1000)
-  const minutes = Math.floor(totalSeconds / 60)
-  const seconds = totalSeconds % 60
+export const formatDuration = (seconds: number | null): string => {
+  if (seconds === null || seconds === 0) return '0분'
 
-  if (seconds === 0) {
-    return `${minutes}분`
-  }
-  return `${minutes}분 ${seconds}초`
+  const minutes = Math.floor(seconds / 60)
+  const secs = seconds % 60
+
+  if (minutes === 0) return `${secs}초`
+  if (secs === 0) return `${minutes}분`
+  return `${minutes}분 ${secs}초`
+}
+
+export const formatDurationMs = (ms: number | null): string => {
+  if (ms === null || ms === 0) return '0분'
+  return formatDuration(Math.round(ms / 1000))
 }

--- a/src/shared/ui/dialog.tsx
+++ b/src/shared/ui/dialog.tsx
@@ -62,7 +62,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+            className="ring-offset-background focus-visible:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 cursor-pointer rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
             <span className="sr-only">Close</span>


### PR DESCRIPTION
## 변경 사항

- 신규 파일 생성
    - DeletePausedInterviewModal.tsx - PAUSED 면접 목록에서 항목별 삭제 버튼을 제공하는 모달
    - InterviewStartGuideModal.tsx - 면접 시작 클릭 시 PAUSED 면접이 있을 때 표시되는 안내 모달 (이어하기 / 새 면접 선택, PAUSED 5개 초과 시 삭제 유도)
    - ResumeInterviewModal.tsx - PAUSED 면접 목록을 보여주고 선택 시 /interview?restart=true&id={intvId}로 이동
    - useIntvListQuery.ts - getIntvListAction 기반 TanStack Query 훅, IN_PROGRESS 리포트 있을 시 30초 폴링

- 삭제 파일
    - useReportListQuery.ts - useIntvListQuery로 변경
  
- API 타입 변경
    - history.service.ts , history.action.ts , history/types.ts , api/types.ts , api/index.ts

- formatDuration 기반 formatDurationMs 구현 -> 리포트 상세에서 평균 답변 시간 0분 50초일 경우 50초로만 표기되게 변경
- 면접 시작 버튼 클릭 시 이어하기가 5개 일경우 면접 삭제 UI 구현
- 면접 기록에서 이어하기 카드 보여지게 수정
- 이어하기 카드에 면접 제목 표기되게 수정

## 리뷰 필요

- 이어하기 로직 확인 필요

close #73 
