### PR TITLE
feat: 이어하기(면접 재개) 기능 구현

### DIFF
--- a/src/featured/history/components/HistoryContainer.tsx
+++ b/src/featured/history/components/HistoryContainer.tsx
@@ -1,23 +1,12 @@
 'use client'
 
 import Link from 'next/link'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useMemo } from 'react'
 import { motion } from 'framer-motion'
-import { Card } from '@/shared/ui/card'
 import { FileText, Inbox } from 'lucide-react'
 import { InterviewReportItem } from '@/featured/history/types'
 import { getReportCardType } from '@/featured/history/constants'
-import { CardContainer } from '@/featured/history/components/cards/CardContainer'
-import {
-  CompletedCardBack,
-  CompletedCardFront,
-} from '@/featured/history/components/cards/CompletedCard'
-import { FailedCard } from '@/featured/history/components/cards/FailedCard'
-import { PendingCard } from './cards/PendingCard'
-import { AnalysingCard } from './cards/AnalysingCard'
-import { trackEvent } from '@/shared/lib/utils/analytics'
-import { useRageClick } from '../hooks/useRageClick'
+import { FlipCard } from '@/featured/history/components/cards/FlipCard'
 import { usePageVisibilityTracker } from '../hooks/usePageVisibilityTracker'
 
 interface HistoryContainerProps {
@@ -25,129 +14,6 @@ interface HistoryContainerProps {
   search: string
   currentPage: number
   itemsPerPage: number
-}
-
-interface FlipCardProps {
-  record: InterviewReportItem
-}
-
-function FlipCard({ record }: FlipCardProps) {
-  const router = useRouter()
-  const [isHovered, setIsHovered] = useState(false)
-
-  const cardType = getReportCardType(record.intvStatus, record.report?.reportStatus)
-
-  const prevCardType = useRef<string | null>(null)
-
-  const isCompleted = cardType === 'completedCard'
-  const isAnalysing = cardType === 'analysingCard'
-
-  // AI 리포트 대기 마찰률: 리포트 단위 기준
-  const reportId = record.report?.reportId
-
-  useEffect(() => {
-    if (cardType === 'analysingCard' && prevCardType.current !== 'analysingCard' && reportId) {
-      trackEvent('report_gen_start', {
-        category: 'ai_report',
-        report_id: reportId,
-      })
-
-      const waitingSessionKey = `report_waiting_session:${reportId}`
-
-      // 마찰률의 분모 이벤트, 같은 리포트 대기 건은 세션 내 1회만 잡음
-      if (!sessionStorage.getItem(waitingSessionKey)) {
-        sessionStorage.setItem(waitingSessionKey, 'true')
-
-        trackEvent('report_waiting_session', {
-          category: 'ai_report',
-          report_id: reportId,
-          page: 'history',
-          status: 'generating',
-        })
-      }
-    }
-
-    if (prevCardType.current === 'analysingCard' && cardType === 'completedCard' && reportId) {
-      trackEvent('report_gen_complete', {
-        category: 'ai_report',
-        report_id: reportId,
-      })
-    }
-
-    prevCardType.current = cardType
-  }, [cardType, reportId])
-
-  const handleRageClick = useCallback(() => {
-    if (!isAnalysing || !reportId) return
-
-    // 분석 중 카드에서 2초 내 3회 클릭  감지되면 마찰 이벤트로 전송
-    trackEvent(
-      'report_waiting_rage_click',
-      {
-        category: 'user_frustration',
-        report_id: reportId,
-        page: 'history',
-        status: 'generating',
-        click_count: 3,
-        window_ms: 2000,
-      },
-      { clarity: true },
-    )
-  }, [isAnalysing, reportId])
-
-  // 분노의 클릭 카운트 : 분석 중 카드 클릭에서만 수행
-  const { registerRageClick } = useRageClick(handleRageClick)
-
-  if (!cardType) return null
-
-  // 카드 상태에 따라 완료 카드는 상세로 이동하고, 분석 중 카드는 rage click 후보로 등록
-  const handleCardClick = () => {
-    if (isCompleted) {
-      router.push(`/report/${record.intvId}`)
-      return
-    }
-
-    if (isAnalysing) {
-      registerRageClick()
-    }
-  }
-
-  return (
-    <div
-      onClick={handleCardClick}
-      onMouseEnter={() => {
-        if (isCompleted) {
-          setIsHovered(true)
-        }
-      }}
-      onMouseLeave={() => {
-        if (isCompleted) {
-          setIsHovered(false)
-        }
-      }}
-      className={`h-full w-full ${isCompleted ? 'cursor-pointer' : 'cursor-default'}`}
-    >
-      <CardContainer isHovered={isHovered}>
-        <Card className="absolute inset-0 flex flex-col overflow-hidden backface-hidden">
-          {cardType === 'completedCard' && <CompletedCardFront record={record} />}
-          {cardType === 'pendingCard' && (
-            <PendingCard intvId={record.intvId} title={record.title} />
-          )}
-          {cardType === 'analysingCard' && <AnalysingCard />}
-          {cardType === 'failedCard' && <FailedCard record={record} />}
-        </Card>
-
-        {isCompleted && (
-          <Card
-            className="absolute inset-0 overflow-hidden antialiased backface-hidden"
-            style={{ transform: 'rotateY(180deg) translateZ(1px)' }}
-          >
-            <CompletedCardBack record={record} />
-          </Card>
-        )}
-      </CardContainer>
-    </div>
-  )
 }
 
 export function HistoryContainer({

--- a/src/featured/history/components/cards/FlipCard.tsx
+++ b/src/featured/history/components/cards/FlipCard.tsx
@@ -30,7 +30,6 @@ export function FlipCard({ record }: FlipCardProps) {
 
   const isCompleted = cardType === 'completedCard'
   const isAnalysing = cardType === 'analysingCard'
-  const isPending = cardType === 'pendingCard'
 
   // AI 리포트 대기 마찰률: 리포트 단위 기준
   const reportId = record.report?.reportId
@@ -99,9 +98,6 @@ export function FlipCard({ record }: FlipCardProps) {
 
     if (isAnalysing) {
       registerRageClick()
-    }
-
-    if (isPending) {
     }
   }
 

--- a/src/featured/history/components/cards/FlipCard.tsx
+++ b/src/featured/history/components/cards/FlipCard.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Card } from '@/shared/ui/card'
+import { InterviewReportItem } from '@/featured/history/types'
+import { getReportCardType } from '@/featured/history/constants'
+import { CardContainer } from '@/featured/history/components/cards/CardContainer'
+import {
+  CompletedCardBack,
+  CompletedCardFront,
+} from '@/featured/history/components/cards/CompletedCard'
+import { FailedCard } from '@/featured/history/components/cards/FailedCard'
+import { PendingCard } from '@/featured/history/components/cards/PendingCard'
+import { AnalysingCard } from '@/featured/history/components/cards/AnalysingCard'
+import { trackEvent } from '@/shared/lib/utils/analytics'
+import { useRageClick } from '@/featured/history/hooks/useRageClick'
+
+interface FlipCardProps {
+  record: InterviewReportItem
+}
+
+export function FlipCard({ record }: FlipCardProps) {
+  const router = useRouter()
+  const [isHovered, setIsHovered] = useState(false)
+
+  const cardType = getReportCardType(record.intvStatus, record.report?.reportStatus)
+
+  const prevCardType = useRef<string | null>(null)
+
+  const isCompleted = cardType === 'completedCard'
+  const isAnalysing = cardType === 'analysingCard'
+  const isPending = cardType === 'pendingCard'
+
+  // AI 리포트 대기 마찰률: 리포트 단위 기준
+  const reportId = record.report?.reportId
+
+  useEffect(() => {
+    if (cardType === 'analysingCard' && prevCardType.current !== 'analysingCard' && reportId) {
+      trackEvent('report_gen_start', {
+        category: 'ai_report',
+        report_id: reportId,
+      })
+
+      const waitingSessionKey = `report_waiting_session:${reportId}`
+
+      // 마찰률의 분모 이벤트, 같은 리포트 대기 건은 세션 내 1회만 잡음
+      if (!sessionStorage.getItem(waitingSessionKey)) {
+        sessionStorage.setItem(waitingSessionKey, 'true')
+
+        trackEvent('report_waiting_session', {
+          category: 'ai_report',
+          report_id: reportId,
+          page: 'history',
+          status: 'generating',
+        })
+      }
+    }
+
+    if (prevCardType.current === 'analysingCard' && cardType === 'completedCard' && reportId) {
+      trackEvent('report_gen_complete', {
+        category: 'ai_report',
+        report_id: reportId,
+      })
+    }
+
+    prevCardType.current = cardType
+  }, [cardType, reportId])
+
+  const handleRageClick = useCallback(() => {
+    if (!isAnalysing || !reportId) return
+
+    // 분석 중 카드에서 2초 내 3회 클릭  감지되면 마찰 이벤트로 전송
+    trackEvent(
+      'report_waiting_rage_click',
+      {
+        category: 'user_frustration',
+        report_id: reportId,
+        page: 'history',
+        status: 'generating',
+        click_count: 3,
+        window_ms: 2000,
+      },
+      { clarity: true },
+    )
+  }, [isAnalysing, reportId])
+
+  // 분노의 클릭 카운트 : 분석 중 카드 클릭에서만 수행
+  const { registerRageClick } = useRageClick(handleRageClick)
+
+  if (!cardType) return null
+
+  // 카드 상태에 따라 완료 카드는 상세로 이동하고, 분석 중 카드는 rage click 후보로 등록
+  const handleCardClick = () => {
+    if (isCompleted) {
+      router.push(`/report/${record.intvId}`)
+      return
+    }
+
+    if (isAnalysing) {
+      registerRageClick()
+    }
+
+    if (isPending) {
+    }
+  }
+
+  return (
+    <div
+      onClick={handleCardClick}
+      onMouseEnter={() => {
+        if (isCompleted) {
+          setIsHovered(true)
+        }
+      }}
+      onMouseLeave={() => {
+        if (isCompleted) {
+          setIsHovered(false)
+        }
+      }}
+      className={`h-full w-full ${isCompleted ? 'cursor-pointer' : 'cursor-default'}`}
+    >
+      <CardContainer isHovered={isHovered}>
+        <Card className="absolute inset-0 flex flex-col overflow-hidden backface-hidden">
+          {cardType === 'completedCard' && <CompletedCardFront record={record} />}
+          {cardType === 'pendingCard' && (
+            <PendingCard intvId={record.intvId} title={record.title} />
+          )}
+          {cardType === 'analysingCard' && <AnalysingCard />}
+          {cardType === 'failedCard' && <FailedCard record={record} />}
+        </Card>
+
+        {isCompleted && (
+          <Card
+            className="absolute inset-0 overflow-hidden antialiased backface-hidden"
+            style={{ transform: 'rotateY(180deg) translateZ(1px)' }}
+          >
+            <CompletedCardBack record={record} />
+          </Card>
+        )}
+      </CardContainer>
+    </div>
+  )
+}

--- a/src/featured/history/components/cards/PendingCard.tsx
+++ b/src/featured/history/components/cards/PendingCard.tsx
@@ -12,7 +12,6 @@ export function PendingCard({ intvId, title }: PendingCardProps) {
     <motion.div whileHover="hover" className="h-full">
       <Link
         href={`/interview?restart=true&id=${intvId}`}
-        onClick={(e) => e.stopPropagation()}
         className="flex h-full flex-col items-center justify-center gap-2 p-3 text-center @[180px]:gap-3 @[180px]:p-4 @[220px]:gap-4 @[220px]:p-5 @[280px]:gap-6 @[280px]:p-6"
       >
         <div className="rounded-full bg-linear-to-br from-green-100 to-emerald-100 p-3 @[180px]:p-4 @[220px]:p-5 @[280px]:p-6">

--- a/src/featured/history/services/history.service.ts
+++ b/src/featured/history/services/history.service.ts
@@ -1,4 +1,5 @@
-import { ApiResponse, PaginatedResponse, serverApi } from '@/shared/lib/api'
+import { ApiResponse, serverApi } from '@/shared/lib/api'
+import { PaginatedResponse } from '@/shared/lib/api/types'
 import { InterviewReportItem } from '../types'
 
 export async function getIntvList(): Promise<ApiResponse<InterviewReportItem[]>> {

--- a/src/featured/interview/actions/interview.action.ts
+++ b/src/featured/interview/actions/interview.action.ts
@@ -15,6 +15,7 @@ import {
   IssueVideoPresignedUrlResponse,
   AnswerAnalysisResponse,
   InterviewBatchPayload,
+  RestartContextInterviewResponse,
 } from '../types'
 import {
   completeFileUpload,
@@ -27,6 +28,7 @@ import {
   issueVideoPresignedUrl,
   pauseInterview,
   requestAnswerAnalysis,
+  restartContextInterview,
   restartInterview,
   sendGazeStats,
   startInterview,
@@ -140,7 +142,14 @@ export async function pauseInterviewAction(intvId: number): Promise<ApiResponse<
   return withAction(() => pauseInterview(intvId))
 }
 
-// 면접 재개
+// 이어하기용 질문 컨텍스트 조회
+export async function restartContextInterviewAction(
+  intvId: number,
+): Promise<ApiResponse<RestartContextInterviewResponse>> {
+  return withAction(() => restartContextInterview(intvId))
+}
+
+// 면접 재개(이어하기)
 export async function restartInterviewAction(intvId: number): Promise<ApiResponse<null>> {
   return withAction(() => restartInterview(intvId))
 }

--- a/src/featured/interview/components/InterviewLayout.tsx
+++ b/src/featured/interview/components/InterviewLayout.tsx
@@ -6,11 +6,29 @@ import { EndDialogModal } from '@/featured/interview/components/EndDialogModal'
 import { InterviewSetupModal } from '@/featured/interview/components/InterviewSetupModal'
 import { InterviewContainer } from '@/featured/interview/components/InterviewContainer'
 import { useInterview } from '@/featured/interview/hooks/useInterview'
+import { restartContextInterviewAction } from '@/featured/interview/actions/interview.action'
 
 export function InterviewLayout() {
   const session = useInterview()
   const searchParams = useSearchParams()
   const isRestart = searchParams.get('restart') === 'true'
+  const idParam = searchParams.get('id')
+
+  useEffect(() => {
+    if (isRestart && idParam) {
+      const intvId = Number(idParam)
+      if (!isNaN(intvId)) {
+        session.setInterviewId(intvId)
+        const fetchData = async () => {
+          const res = await restartContextInterviewAction(intvId)
+          if (res.success && res.data) {
+            session.setRestartContext(res.data)
+          }
+        }
+        fetchData()
+      }
+    }
+  }, [isRestart, idParam])
 
   useEffect(() => {
     const { interviewId, phase } = session

--- a/src/featured/interview/components/InterviewSetupModal.tsx
+++ b/src/featured/interview/components/InterviewSetupModal.tsx
@@ -20,6 +20,7 @@ import {
   createInterviewAction,
   generateInterviewQuestionAction,
   issuePresignedUrlAction,
+  restartInterviewAction,
   startInterviewAction,
   updateInterviewTitleAction,
 } from '@/featured/interview/actions/interview.action'
@@ -51,7 +52,9 @@ export function InterviewSetupModal({ session, isRestart = false }: InterviewSet
   const [isPollingActive, setIsPollingActive] = useState(false)
 
   const cameraHandler = useCameraHandler()
-  const micPermission = useMicPermission(() => setIsPollingActive(true))
+  const micPermission = useMicPermission(() => {
+    if (!isRestart) setIsPollingActive(true)
+  })
   const micRecorder = useMicRecorder(micPermission.micStreamRef)
 
   const handlePollingComplete = useCallback(() => {
@@ -62,8 +65,12 @@ export function InterviewSetupModal({ session, isRestart = false }: InterviewSet
     isPollingActive,
     handlePollingComplete,
   )
+  const activeQuestions =
+    isRestart && session.unansweredQuestions?.length
+      ? session.unansweredQuestions
+      : questions
 
-  const isQuestionsReady = questions && Array.isArray(questions) && questions.length > 0
+  const isQuestionsReady = !!activeQuestions && activeQuestions.length > 0
 
   const { cleanupCamera } = cameraHandler
   const { cleanupMic } = micPermission
@@ -387,7 +394,11 @@ export function InterviewSetupModal({ session, isRestart = false }: InterviewSet
                   }
 
                   if (session.interviewId) {
-                    await startInterviewAction(session.interviewId)
+                    if (isRestart) {
+                      await restartInterviewAction(session.interviewId)
+                    } else {
+                      await startInterviewAction(session.interviewId)
+                    }
                   }
 
                   trackEvent('start_interview', { category: 'interview_setup' })
@@ -396,7 +407,7 @@ export function InterviewSetupModal({ session, isRestart = false }: InterviewSet
                     basePose: cameraHandler.basePose,
                     stream: cameraHandler.cameraStream,
                     interviewId: session.interviewId,
-                    questions: questions ?? [],
+                    questions: activeQuestions ?? [],
                   })
                 }}
                 className="cursor-pointer gap-2"

--- a/src/featured/interview/components/setup/DocumentStep.tsx
+++ b/src/featured/interview/components/setup/DocumentStep.tsx
@@ -31,7 +31,6 @@ export function DocumentStep({
   onComplete,
   isUploading,
 }: DocumentStepProps) {
-  // GA4 이벤트 전송 코드 수정 (중복 제거 및 단축키 사용)
   useEffect(() => {
     trackEvent('enter_upload_step', { category: 'interview_setup' })
   }, [])

--- a/src/featured/interview/hooks/useInterview.ts
+++ b/src/featured/interview/hooks/useInterview.ts
@@ -1,12 +1,13 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { TOTAL_ANSWER_TIME, TOTAL_THINK_TIME } from '@/featured/interview/constants'
 import type {
   InterviewQuestions,
   InterviewSetupConfig,
   Phase,
+  RestartContextInterviewResponse,
   uploadAnswer,
 } from '@/featured/interview/types'
 import {
@@ -36,6 +37,16 @@ export function useInterview() {
   const [cameraStream, setCameraStream] = useState<MediaStream | null>(null)
   const [interviewId, setInterviewId] = useState<number | null>(null)
   const [interviewQuestions, setInterviewQuestions] = useState<InterviewQuestions[]>([])
+  const [restartContext, setRestartContext] = useState<RestartContextInterviewResponse | null>(null)
+
+  const unansweredQuestions = useMemo(() => {
+    return restartContext?.questions
+      .filter((q) => !q.answered)
+      .map((q) => ({
+        questionSetId: q.questionSetId,
+        content: q.content,
+      }))
+  }, [restartContext])
 
   const phaseRef = useRef(phase)
   const currentQuestionRef = useRef(currentQuestion)
@@ -89,6 +100,7 @@ export function useInterview() {
       setInterviewId(config.interviewId)
     }
     setInterviewQuestions(config.questions ?? [])
+    setCurrentQuestion(restartContext?.answeredCount ?? 0)
     setShowSetup(false)
     setTypingKey((prev) => prev + 1)
     setQuestionRevealed(false)
@@ -266,6 +278,9 @@ export function useInterview() {
     interviewQuestions,
     interviewId,
     setInterviewId,
+    restartContext,
+    setRestartContext,
+    unansweredQuestions,
     phase,
     timeLeft,
     micOn,

--- a/src/featured/interview/hooks/useInterview.ts
+++ b/src/featured/interview/hooks/useInterview.ts
@@ -100,7 +100,7 @@ export function useInterview() {
       setInterviewId(config.interviewId)
     }
     setInterviewQuestions(config.questions ?? [])
-    setCurrentQuestion(restartContext?.answeredCount ?? 0)
+    setCurrentQuestion(0)
     setShowSetup(false)
     setTypingKey((prev) => prev + 1)
     setQuestionRevealed(false)

--- a/src/featured/interview/services/interview.service.ts
+++ b/src/featured/interview/services/interview.service.ts
@@ -20,7 +20,7 @@ import {
 export async function createInterview(
   title: string,
 ): Promise<ApiResponse<CreateInterviewResponse>> {
-  return await serverApi.post<CreateInterviewResponse>('/api/v1/intvs', {
+  return await serverApi.post('/api/v1/intvs', {
     title,
   })
 }
@@ -100,7 +100,7 @@ export async function requestAnswerAnalysis(
 
 // 면접 완료
 export async function finishInterview(intvId: number): Promise<ApiResponse<null>> {
-  return await serverApi.patch<null>(`/api/v1/intvs/${intvId}/finish`)
+  return await serverApi.patch(`/api/v1/intvs/${intvId}/finish`)
 }
 
 // 시선/고개 통계 서버 전송
@@ -110,12 +110,12 @@ export async function sendGazeStats(questionSetId: number, payload: InterviewBat
 
 // 면접 시작
 export async function startInterview(intvId: number): Promise<ApiResponse<null>> {
-  return await serverApi.patch<null>(`/api/v1/intvs/${intvId}/start`)
+  return await serverApi.patch(`/api/v1/intvs/${intvId}/start`)
 }
 
 // 면저 중단
 export async function pauseInterview(intvId: number): Promise<ApiResponse<null>> {
-  return await serverApi.patch<null>(`/api/v1/intvs/${intvId}/pause`)
+  return await serverApi.patch(`/api/v1/intvs/${intvId}/pause`)
 }
 
 // 이어하기용 질문 컨텍스트 조회
@@ -127,5 +127,5 @@ export async function restartContextInterview(
 
 // 면접 재개(이어하기)
 export async function restartInterview(intvId: number): Promise<ApiResponse<null>> {
-  return await serverApi.patch<null>(`/api/v1/intvs/${intvId}/resume`)
+  return await serverApi.patch(`/api/v1/intvs/${intvId}/resume`)
 }

--- a/src/featured/interview/services/interview.service.ts
+++ b/src/featured/interview/services/interview.service.ts
@@ -13,6 +13,7 @@ import {
   CompleteVideoFileUploadResponse,
   AnswerAnalysisResponse,
   InterviewBatchPayload,
+  RestartContextInterviewResponse,
 } from '../types'
 
 // 면접 생성(제목 추가)
@@ -84,7 +85,6 @@ export async function completeVideoFileUpload(
   intvId: number,
   video: VideoInfo,
 ): Promise<ApiResponse<CompleteVideoFileUploadResponse>> {
-  console.log('페이로드:', questionSetId, intvId, video)
   return await serverApi.post(`/api/v1/intvs/${questionSetId}/answers`, {
     intvId,
     ...video,
@@ -118,7 +118,14 @@ export async function pauseInterview(intvId: number): Promise<ApiResponse<null>>
   return await serverApi.patch<null>(`/api/v1/intvs/${intvId}/pause`)
 }
 
-// 면접 재개
+// 이어하기용 질문 컨텍스트 조회
+export async function restartContextInterview(
+  intvId: number,
+): Promise<ApiResponse<RestartContextInterviewResponse>> {
+  return await serverApi.get(`/api/v1/intvs/${intvId}/resume-context`)
+}
+
+// 면접 재개(이어하기)
 export async function restartInterview(intvId: number): Promise<ApiResponse<null>> {
   return await serverApi.patch<null>(`/api/v1/intvs/${intvId}/resume`)
 }

--- a/src/featured/interview/types.ts
+++ b/src/featured/interview/types.ts
@@ -176,7 +176,7 @@ export interface Question {
   answerStatus: AnswerStatus
 }
 
-export interface RestartContextInterviewData {
+export interface RestartContextInterviewResponse {
   intvId: number
   status: InterviewStatus
   totalQuestionCount: number
@@ -186,12 +186,4 @@ export interface RestartContextInterviewData {
   nextQuestionOrder: number | null
   nextQuestionContent: string | null
   questions: Question[]
-}
-
-export interface RestartContextInterviewResponse {
-  success: boolean
-  code: string
-  message: string
-  data: RestartContextInterviewData
-  errors: unknown | null
 }

--- a/src/featured/interview/types.ts
+++ b/src/featured/interview/types.ts
@@ -120,7 +120,7 @@ export interface GetInterviewQuestionsResponse {
 
 export interface IssueVideoPresignedUrlRequest {
   originalFileName: string
-  contentType: string // 테스트 후 타입 좁히기 필요
+  contentType: string
   fileSizeBytes: number
 }
 
@@ -155,4 +155,43 @@ export interface uploadAnswer {
   videoBlob: Blob
   questionSetId: number
   interviewId: number
+}
+
+export type AnswerStatus =
+  | 'UPLOADED'
+  | 'STT_PENDING'
+  | 'STT_PROCESSING'
+  | 'STT_COMPLETED'
+  | 'STT_FAILED'
+  | null
+
+export type InterviewStatus = 'READY' | 'IN_PROGRESS' | 'PAUSED' | 'FINISHED'
+
+export interface Question {
+  questionSetId: number
+  questionOrder: number
+  content: string
+  answered: boolean
+  answerId: number | null
+  answerStatus: AnswerStatus
+}
+
+export interface RestartContextInterviewData {
+  intvId: number
+  status: InterviewStatus
+  totalQuestionCount: number
+  answeredCount: number
+  completed: boolean
+  nextQuestionSetId: number | null
+  nextQuestionOrder: number | null
+  nextQuestionContent: string | null
+  questions: Question[]
+}
+
+export interface RestartContextInterviewResponse {
+  success: boolean
+  code: string
+  message: string
+  data: RestartContextInterviewData
+  errors: unknown | null
 }


### PR DESCRIPTION
## 변경 사항

- FlipCard.tsx - HistoryContainer.tsx에서 분리하여 cards/ 폴더로 이동                                                                                                                        
- PendingCard.tsx - e.stopPropagation() 제거로 클릭 이벤트 버블링 허용                                                                                                                       
- interview.service.ts - restartContextInterview, restartInterview 서비스 함수 추가                                                                                     
- interview.action.ts - restartContextInterviewAction, restartInterviewAction 액션 레이어 추가
- InterviewLayout.tsx - URL restart=true&id 파라미터 감지 시 setInterviewId + restartContextInterviewAction 호출 후 session.setRestartContext 저장                                           
- useInterview.ts - restartContext 상태 추가, unansweredQuestions (미답변 질문에서 answeredCount 기준으로 시작 질문 인덱스 세팅)

close #78 
