### PR TITLE
fix: 면접화면 뒤로가기 API 안붙어잇는 오류 수정

### DIFF
--- a/src/featured/interview/components/InterviewContainer.tsx
+++ b/src/featured/interview/components/InterviewContainer.tsx
@@ -23,6 +23,7 @@ export function InterviewContainer({ session }: InterviewPageProps) {
         isActive={session.isActive}
         questions={session.interviewQuestions}
         onEndClick={() => session.setShowEndDialog(true)}
+        onBackClick={() => session.setShowEndDialog(true)}
       />
       <QuestionBanner
         currentQuestion={session.currentQuestion}

--- a/src/featured/interview/components/InterviewContainer.tsx
+++ b/src/featured/interview/components/InterviewContainer.tsx
@@ -14,6 +14,8 @@ export function InterviewContainer({ session }: InterviewPageProps) {
   const currentQuestionSetId =
     session.interviewQuestions[session.currentQuestion]?.questionSetId ?? null
 
+  const handleStopRequest = () => session.setShowEndDialog(true)
+
   return (
     <div className="relative flex h-screen flex-col overflow-hidden bg-slate-950 text-white">
       <ProcessBar
@@ -22,8 +24,8 @@ export function InterviewContainer({ session }: InterviewPageProps) {
         phase={session.phase}
         isActive={session.isActive}
         questions={session.interviewQuestions}
-        onEndClick={() => session.setShowEndDialog(true)}
-        onBackClick={() => session.setShowEndDialog(true)}
+        onEndClick={handleStopRequest}
+        onBackClick={handleStopRequest}
       />
       <QuestionBanner
         currentQuestion={session.currentQuestion}

--- a/src/featured/interview/components/InterviewLayout.tsx
+++ b/src/featured/interview/components/InterviewLayout.tsx
@@ -42,10 +42,17 @@ export function InterviewLayout() {
     if (interviewId === null || phase === 'ready' || phase === 'finished') return
 
     const sendPause = () => {
-      navigator.sendBeacon(
-        '/api/interview/pause',
-        new Blob([JSON.stringify({ intvId: interviewId })], { type: 'application/json' }),
-      )
+      const body = JSON.stringify({ intvId: interviewId })
+      const blob = new Blob([body], { type: 'application/json' })
+      const sent = navigator.sendBeacon('/api/interview/pause', blob)
+      if (!sent) {
+        fetch('/api/interview/pause', {
+          method: 'POST',
+          body,
+          headers: { 'Content-Type': 'application/json' },
+          keepalive: true,
+        }).catch(() => {})
+      }
     }
 
     const handlePopState = () => {

--- a/src/featured/interview/components/InterviewLayout.tsx
+++ b/src/featured/interview/components/InterviewLayout.tsx
@@ -48,12 +48,18 @@ export function InterviewLayout() {
       )
     }
 
+    const handlePopState = () => {
+      if (!window.location.pathname.startsWith('/interview')) {
+        sendPause()
+      }
+    }
+
     window.addEventListener('beforeunload', sendPause)
-    window.addEventListener('popstate', sendPause)
+    window.addEventListener('popstate', handlePopState)
 
     return () => {
       window.removeEventListener('beforeunload', sendPause)
-      window.removeEventListener('popstate', sendPause)
+      window.removeEventListener('popstate', handlePopState)
     }
   }, [session.interviewId, session.phase])
 

--- a/src/featured/interview/components/screen/ProcessBar.tsx
+++ b/src/featured/interview/components/screen/ProcessBar.tsx
@@ -30,6 +30,7 @@ export function ProcessBar({
         <Button
           variant="ghost"
           size="icon"
+          aria-label="면접 중단"
           className="h-8 w-8 text-white/60 hover:bg-white/10 hover:text-white"
           onClick={onBackClick}
         >

--- a/src/featured/interview/components/screen/ProcessBar.tsx
+++ b/src/featured/interview/components/screen/ProcessBar.tsx
@@ -31,7 +31,7 @@ export function ProcessBar({
           variant="ghost"
           size="icon"
           aria-label="면접 중단"
-          className="h-8 w-8 text-white/60 hover:bg-white/10 hover:text-white"
+          className="h-8 w-8 cursor-pointer text-white/60 hover:bg-white/10 hover:text-white"
           onClick={onBackClick}
         >
           <ArrowLeft className="h-4 w-4" />

--- a/src/featured/interview/components/screen/ProcessBar.tsx
+++ b/src/featured/interview/components/screen/ProcessBar.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import Link from 'next/link'
 import { Button } from '@/shared/ui/button'
 import { ArrowLeft, Power } from 'lucide-react'
 import type { Phase, InterviewQuestions } from '@/featured/interview/types'
@@ -13,6 +12,7 @@ interface TopBarProps {
   isActive: boolean
   questions: InterviewQuestions[]
   onEndClick: () => void
+  onBackClick: () => void
 }
 
 export function ProcessBar({
@@ -22,6 +22,7 @@ export function ProcessBar({
   isActive,
   questions,
   onEndClick,
+  onBackClick,
 }: TopBarProps) {
   return (
     <header className="relative z-20 flex items-center justify-between border-b border-white/10 bg-slate-900/90 px-4 py-3 backdrop-blur">
@@ -30,11 +31,9 @@ export function ProcessBar({
           variant="ghost"
           size="icon"
           className="h-8 w-8 text-white/60 hover:bg-white/10 hover:text-white"
-          asChild
+          onClick={onBackClick}
         >
-          <Link href="/dashboard">
-            <ArrowLeft className="h-4 w-4" />
-          </Link>
+          <ArrowLeft className="h-4 w-4" />
         </Button>
         <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-white">
           <Image


### PR DESCRIPTION
## 변경 사항

- 브라우저 앞으로가기 클릭시 pause API가 호출되던 현상 수정
    - 중지 시키기 전에 url (/interview)인지 확인하는 로직 추가
- 면접 화면 뒤로가기 UI 버튼에 API 부착
- sendBeacon 혹시 모를 실패를 위해 방어 코드 추가

## 리뷰 필요

- handlePopState url 확인하는 로직 리뷰 필요

close #93 
