### PR TITLE
feat: 설정 페이지 ui 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "framer-motion": "^12.34.3",
         "lucide-react": "^0.575.0",
         "next": "^16.2.4",
+        "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -7191,7 +7192,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9280,6 +9280,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "framer-motion": "^12.34.3",
     "lucide-react": "^0.575.0",
     "next": "^16.2.4",
+    "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/src/app/(authenticated)/(sidebar)/settings/page.tsx
+++ b/src/app/(authenticated)/(sidebar)/settings/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next'
+import { SettingsHeader } from '@/featured/settings/components/SettingsHeader'
+import { AccountCard } from '@/featured/settings/components/AccountCard'
+import { GeneralCard } from '@/featured/settings/components/GeneralCard'
+
+export const metadata: Metadata = {
+  title: '설정',
+}
+
+export default function SettingsPage() {
+  return (
+    <>
+      <SettingsHeader />
+      <div className="mx-auto grid w-full max-w-2xl grid-cols-1 items-start gap-6 p-6 sm:p-8 lg:grid-cols-1">
+        <GeneralCard />
+        <AccountCard />
+      </div>
+    </>
+  )
+}

--- a/src/app/(authenticated)/(sidebar)/settings/page.tsx
+++ b/src/app/(authenticated)/(sidebar)/settings/page.tsx
@@ -12,8 +12,8 @@ export default function SettingsPage() {
     <>
       <SettingsHeader />
       <div className="mx-auto grid w-full max-w-2xl grid-cols-1 items-start gap-6 p-6 sm:p-8 lg:grid-cols-1">
-        <GeneralCard />
         <AccountCard />
+        <GeneralCard />
       </div>
     </>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from 'next'
 import { Geist, Geist_Mono } from 'next/font/google'
 import { TooltipProvider } from '@/shared/ui/tooltip'
 import ReactQueryProvider from '@/shared/lib/ReactQueryProvider'
-import { Toaster } from 'sonner'
+import { ThemeProvider } from '@/shared/lib/ThemeProvider'
+import { Toaster } from '@/shared/ui/sonner'
 import './globals.css'
 import { GoogleAnalytics } from '@next/third-parties/google'
 import ClarityProvider from '@/shared/lib/ClarityProvider'
@@ -60,20 +61,27 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="ko">
+    <html lang="ko" suppressHydrationWarning>
       <head>
         <link rel="preconnect" href="https://cdn.jsdelivr.net" crossOrigin="anonymous" />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}>
-        <GoogleAnalytics
-          gaId={process.env.NEXT_PUBLIC_GA_ID || ''}
-          debugMode={process.env.NODE_ENV === 'development'}
-        />
-        <ClarityProvider clarityId={process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID || ''} />
-        <ReactQueryProvider>
-          <TooltipProvider delayDuration={300}>{children}</TooltipProvider>
-        </ReactQueryProvider>
-        <Toaster richColors position="top-right" />
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="light"
+          enableSystem={false}
+          disableTransitionOnChange
+        >
+          <GoogleAnalytics
+            gaId={process.env.NEXT_PUBLIC_GA_ID || ''}
+            debugMode={process.env.NODE_ENV === 'development'}
+          />
+          <ClarityProvider clarityId={process.env.NEXT_PUBLIC_CLARITY_PROJECT_ID || ''} />
+          <ReactQueryProvider>
+            <TooltipProvider delayDuration={300}>{children}</TooltipProvider>
+          </ReactQueryProvider>
+          <Toaster richColors position="top-right" />
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/src/featured/settings/components/AccountCard.tsx
+++ b/src/featured/settings/components/AccountCard.tsx
@@ -1,0 +1,21 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card'
+import { Separator } from '@/shared/ui/separator'
+import { SETTINGS_COPY } from '../constants'
+import { ProfileSection } from './ProfileSection'
+import { AccountManagementSection } from './AccountManagementSection'
+
+export function AccountCard() {
+  return (
+    <Card className="py-8">
+      <CardHeader>
+        <CardTitle>{SETTINGS_COPY.sectionAccount}</CardTitle>
+        <CardDescription>{SETTINGS_COPY.sectionAccountDescription}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        <ProfileSection />
+        <Separator />
+        <AccountManagementSection />
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/featured/settings/components/AccountManagementSection.tsx
+++ b/src/featured/settings/components/AccountManagementSection.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import Link from 'next/link'
+import { toast } from 'sonner'
+import { ExternalLink } from 'lucide-react'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/shared/ui/dialog'
+import { Button } from '@/shared/ui/button'
+import { SETTINGS_COPY } from '../constants'
+import { SettingsRow } from './SettingsRow'
+
+export function AccountManagementSection() {
+  const handleWithdraw = () => {
+    toast.info(SETTINGS_COPY.withdrawPendingToast)
+  }
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h3 className="text-sm font-semibold">{SETTINGS_COPY.accountTitle}</h3>
+      <SettingsRow label="이용약관">
+        <Button variant="ghost" size="sm" className="cursor-pointer gap-1.5" asChild>
+          <Link href="/terms" target="_blank">
+            보기
+            <ExternalLink className="h-3.5 w-3.5" />
+          </Link>
+        </Button>
+      </SettingsRow>
+      <SettingsRow label="개인정보처리방침">
+        <Button variant="ghost" size="sm" className="cursor-pointer gap-1.5" asChild>
+          <Link href="/privacy" target="_blank">
+            보기
+            <ExternalLink className="h-3.5 w-3.5" />
+          </Link>
+        </Button>
+      </SettingsRow>
+      <SettingsRow label="회원 탈퇴" description="계정과 모든 면접 기록이 삭제됩니다.">
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button variant="secondary" size="sm" className="cursor-pointer">
+              회원 탈퇴
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>정말 탈퇴하시겠어요?</DialogTitle>
+              <DialogDescription>
+                탈퇴하면 계정 정보와 모든 면접 기록·리포트가 삭제되며 복구할 수 없습니다.
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="outline" className="cursor-pointer">
+                  취소
+                </Button>
+              </DialogClose>
+              <DialogClose asChild>
+                <Button variant="destructive" className="cursor-pointer" onClick={handleWithdraw}>
+                  탈퇴하기
+                </Button>
+              </DialogClose>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </SettingsRow>
+    </section>
+  )
+}

--- a/src/featured/settings/components/AccountManagementSection.tsx
+++ b/src/featured/settings/components/AccountManagementSection.tsx
@@ -44,7 +44,11 @@ export function AccountManagementSection() {
       <SettingsRow label="회원 탈퇴" description="계정과 모든 면접 기록이 삭제됩니다.">
         <Dialog>
           <DialogTrigger asChild>
-            <Button variant="secondary" size="sm" className="cursor-pointer">
+            <Button
+              variant="secondary"
+              size="sm"
+              className="cursor-pointer bg-gray-200 text-gray-500 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-200 dark:hover:bg-gray-600"
+            >
               회원 탈퇴
             </Button>
           </DialogTrigger>

--- a/src/featured/settings/components/AppearanceSection.tsx
+++ b/src/featured/settings/components/AppearanceSection.tsx
@@ -1,0 +1,27 @@
+import { Button } from '@/shared/ui/button'
+import { SETTINGS_COPY, THEME_OPTIONS } from '../constants'
+import { SettingsRow } from './SettingsRow'
+
+export function AppearanceSection() {
+  return (
+    <section className="flex flex-col gap-3">
+      <h3 className="text-sm font-semibold">{SETTINGS_COPY.appearanceTitle}</h3>
+      <SettingsRow label="테마">
+        <div className="border-border flex gap-1 rounded-lg border p-1">
+          {THEME_OPTIONS.map((option) => (
+            <Button
+              key={option.value}
+              variant={option.value === 'light' ? 'secondary' : 'ghost'}
+              size="sm"
+              className="h-7 cursor-pointer px-3 text-xs disabled:pointer-events-auto"
+              disabled
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+      </SettingsRow>
+      <p className="text-muted-foreground text-xs">{SETTINGS_COPY.themePending}</p>
+    </section>
+  )
+}

--- a/src/featured/settings/components/AppearanceSection.tsx
+++ b/src/featured/settings/components/AppearanceSection.tsx
@@ -1,27 +1,43 @@
+'use client'
+
 import { Button } from '@/shared/ui/button'
+import { useTheme } from 'next-themes'
+import { useSyncExternalStore } from 'react'
 import { SETTINGS_COPY, THEME_OPTIONS } from '../constants'
 import { SettingsRow } from './SettingsRow'
 
+const subscribe = () => () => {}
+const getClientSnapshot = () => true
+const getServerSnapshot = () => false
+
 export function AppearanceSection() {
+  const { theme, setTheme } = useTheme()
+  const mounted = useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot)
+
   return (
     <section className="flex flex-col gap-3">
       <h3 className="text-sm font-semibold">{SETTINGS_COPY.appearanceTitle}</h3>
       <SettingsRow label="테마">
         <div className="border-border flex gap-1 rounded-lg border p-1">
-          {THEME_OPTIONS.map((option) => (
-            <Button
-              key={option.value}
-              variant={option.value === 'light' ? 'secondary' : 'ghost'}
-              size="sm"
-              className="h-7 cursor-pointer px-3 text-xs disabled:pointer-events-auto"
-              disabled
-            >
-              {option.label}
-            </Button>
-          ))}
+          {THEME_OPTIONS.map((option) => {
+            const isSelected = mounted && theme === option.value
+
+            return (
+              <Button
+                key={option.value}
+                type="button"
+                variant={isSelected ? 'secondary' : 'ghost'}
+                size="sm"
+                className="h-7 cursor-pointer px-3 text-xs"
+                aria-pressed={isSelected}
+                onClick={() => setTheme(option.value)}
+              >
+                {option.label}
+              </Button>
+            )
+          })}
         </div>
       </SettingsRow>
-      <p className="text-muted-foreground text-xs">{SETTINGS_COPY.themePending}</p>
     </section>
   )
 }

--- a/src/featured/settings/components/GeneralCard.tsx
+++ b/src/featured/settings/components/GeneralCard.tsx
@@ -1,0 +1,21 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/shared/ui/card'
+import { Separator } from '@/shared/ui/separator'
+import { SETTINGS_COPY } from '../constants'
+import { AppearanceSection } from './AppearanceSection'
+import { NotificationSection } from './NotificationSection'
+
+export function GeneralCard() {
+  return (
+    <Card className="py-8">
+      <CardHeader>
+        <CardTitle>{SETTINGS_COPY.sectionGeneral}</CardTitle>
+        <CardDescription>{SETTINGS_COPY.sectionGeneralDescription}</CardDescription>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-6">
+        <AppearanceSection />
+        <Separator />
+        <NotificationSection />
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/featured/settings/components/NotificationSection.tsx
+++ b/src/featured/settings/components/NotificationSection.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { Switch } from '@/shared/ui/switch'
+import { useSettingsStore } from '../store'
+import { SETTINGS_COPY } from '../constants'
+import { useSettingsHydrated } from '../hooks/useSettingsHydrated'
+import { SettingsRow } from './SettingsRow'
+
+export function NotificationSection() {
+  const { notificationEnabled, setNotificationEnabled } = useSettingsStore()
+  const isHydrated = useSettingsHydrated()
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h3 className="text-sm font-semibold">{SETTINGS_COPY.notificationTitle}</h3>
+      <SettingsRow label="알림 받기" description="공지사항과 리포트 완료 소식을 알려드립니다.">
+        <Switch
+          checked={isHydrated ? notificationEnabled : true}
+          disabled={!isHydrated}
+          onCheckedChange={setNotificationEnabled}
+          aria-label="알림 받기"
+        />
+      </SettingsRow>
+      <p className="text-muted-foreground text-xs">{SETTINGS_COPY.localOnlyNotice}</p>
+    </section>
+  )
+}

--- a/src/featured/settings/components/ProfileSection.tsx
+++ b/src/featured/settings/components/ProfileSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { CircleUserRound } from 'lucide-react'
+import { CircleUserRound, SquarePen } from 'lucide-react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar'
 import { Button } from '@/shared/ui/button'
 import { Input } from '@/shared/ui/input'
@@ -91,20 +91,53 @@ function SocialProviderIcon({ provider }: SocialProviderIconProps) {
 
 function NicknameEditor({ initialNickname }: NicknameEditorProps) {
   const [nickname, setNickname] = useState(initialNickname)
+  const [isEditing, setIsEditing] = useState(false)
+
+  const cancelEditing = () => {
+    setNickname(initialNickname)
+    setIsEditing(false)
+  }
+
+  if (!isEditing) {
+    return (
+      <>
+        <span className="min-w-0 flex-1 truncate text-sm">{initialNickname || '-'}</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => setIsEditing(true)}
+          aria-label="닉네임 수정"
+          title="닉네임 수정"
+        >
+          <SquarePen aria-hidden="true" />
+        </Button>
+      </>
+    )
+  }
 
   return (
-    <>
+    <div className="flex min-w-0 flex-1 items-center gap-2">
       <Input
+        autoFocus
         value={nickname}
         onChange={(e) => setNickname(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') {
+            cancelEditing()
+          }
+        }}
         placeholder="닉네임"
         className="h-9"
         aria-label="닉네임"
       />
-      <Button size="sm" disabled>
+      <Button type="button" size="sm" disabled>
         저장
       </Button>
-    </>
+      <Button type="button" variant="outline" size="sm" onClick={cancelEditing}>
+        취소
+      </Button>
+    </div>
   )
 }
 

--- a/src/featured/settings/components/ProfileSection.tsx
+++ b/src/featured/settings/components/ProfileSection.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import { useState } from 'react'
+import { CircleUserRound } from 'lucide-react'
+import { Avatar, AvatarFallback, AvatarImage } from '@/shared/ui/avatar'
+import { Button } from '@/shared/ui/button'
+import { Input } from '@/shared/ui/input'
+import { useAuthStore } from '@/featured/auth/store'
+import { SETTINGS_COPY } from '../constants'
+import { SettingsRow } from './SettingsRow'
+
+interface NicknameEditorProps {
+  initialNickname: string
+}
+
+interface SocialProviderIconProps {
+  provider: string
+}
+
+function GoogleIcon() {
+  return (
+    <svg className="size-5" viewBox="0 0 24 24" aria-hidden="true">
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+        fill="#EA4335"
+      />
+    </svg>
+  )
+}
+
+function KakaoIcon() {
+  return (
+    <svg className="size-5" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 3C6.477 3 2 6.477 2 10.8c0 2.7 1.617 5.076 4.077 6.54l-.977 3.642a.3.3 0 0 0 .44.327l4.217-2.79A12.2 12.2 0 0 0 12 18.6c5.523 0 10-3.477 10-7.8S17.523 3 12 3z" />
+    </svg>
+  )
+}
+
+function SocialProviderIcon({ provider }: SocialProviderIconProps) {
+  const normalizedProvider = provider.toLowerCase()
+
+  if (normalizedProvider === 'google') {
+    return (
+      <span
+        role="img"
+        aria-label="Google 계정"
+        title="Google"
+        className="border-border bg-background flex size-8 items-center justify-center rounded-full border"
+      >
+        <GoogleIcon />
+      </span>
+    )
+  }
+
+  if (normalizedProvider === 'kakao') {
+    return (
+      <span
+        role="img"
+        aria-label="카카오 계정"
+        title="카카오"
+        className="flex size-8 items-center justify-center rounded-full bg-[#FEE500] text-black"
+      >
+        <KakaoIcon />
+      </span>
+    )
+  }
+
+  return (
+    <span
+      role="img"
+      aria-label={`${provider} 계정`}
+      title={provider}
+      className="bg-secondary text-secondary-foreground flex size-8 items-center justify-center rounded-full"
+    >
+      <CircleUserRound className="size-5" aria-hidden="true" />
+    </span>
+  )
+}
+
+function NicknameEditor({ initialNickname }: NicknameEditorProps) {
+  const [nickname, setNickname] = useState(initialNickname)
+
+  return (
+    <>
+      <Input
+        value={nickname}
+        onChange={(e) => setNickname(e.target.value)}
+        placeholder="닉네임"
+        className="h-9"
+        aria-label="닉네임"
+      />
+      <Button size="sm" disabled>
+        저장
+      </Button>
+    </>
+  )
+}
+
+export function ProfileSection() {
+  const { user } = useAuthStore()
+
+  const initials = user?.nickname ? user.nickname.slice(0, 1) : 'U'
+  const nicknameEditorKey = `${user?.id ?? user?.email ?? 'guest'}:${user?.nickname ?? ''}`
+
+  return (
+    <section className="flex flex-col gap-3">
+      <h3 className="text-sm font-semibold">{SETTINGS_COPY.profileTitle}</h3>
+      <div className="flex items-center gap-3">
+        <Avatar className="h-12 w-12">
+          {user?.avatar && <AvatarImage src={user.avatar} alt={user.nickname} />}
+          <AvatarFallback className="bg-primary/10 text-primary text-lg font-semibold">
+            {initials}
+          </AvatarFallback>
+        </Avatar>
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <NicknameEditor key={nicknameEditorKey} initialNickname={user?.nickname ?? ''} />
+        </div>
+      </div>
+      <SettingsRow label="이메일">
+        <span className="text-muted-foreground text-sm">{user?.email ?? '-'}</span>
+      </SettingsRow>
+      {user?.provider && (
+        <SettingsRow label="연결된 소셜 계정">
+          <SocialProviderIcon provider={user.provider} />
+        </SettingsRow>
+      )}
+    </section>
+  )
+}

--- a/src/featured/settings/components/SettingsHeader.tsx
+++ b/src/featured/settings/components/SettingsHeader.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { HeaderActions } from '@/shared/components/header-actions'
+import { SETTINGS_COPY } from '../constants'
+
+export function SettingsHeader() {
+  return (
+    <div className="border-border/50 bg-background/80 flex items-center justify-between border-b px-8 py-5 backdrop-blur">
+      <div>
+        <h1 className="text-xl font-bold">{SETTINGS_COPY.pageTitle}</h1>
+        <p className="text-muted-foreground mt-0.5 text-sm">{SETTINGS_COPY.pageDescription}</p>
+      </div>
+      <HeaderActions />
+    </div>
+  )
+}

--- a/src/featured/settings/components/SettingsRow.tsx
+++ b/src/featured/settings/components/SettingsRow.tsx
@@ -1,0 +1,17 @@
+interface SettingsRowProps {
+  label: string
+  description?: string
+  children?: React.ReactNode
+}
+
+export function SettingsRow({ label, description, children }: SettingsRowProps) {
+  return (
+    <div className="flex items-center justify-between gap-4 py-2.5">
+      <div className="min-w-0">
+        <p className="text-sm font-medium">{label}</p>
+        {description && <p className="text-muted-foreground mt-0.5 text-xs">{description}</p>}
+      </div>
+      <div className="shrink-0">{children}</div>
+    </div>
+  )
+}

--- a/src/featured/settings/constants.ts
+++ b/src/featured/settings/constants.ts
@@ -12,15 +12,12 @@ export const SETTINGS_COPY = {
   appearanceTitle: '화면',
   notificationTitle: '알림',
   localOnlyNotice: '알림 설정은 현재 기기에만 저장됩니다.',
-  nicknamePending: '닉네임 변경은 곧 제공될 예정입니다.',
-  themePending: '테마 변경은 곧 제공될 예정입니다.',
   withdrawPendingToast: '회원 탈퇴 기능은 준비 중입니다.',
 } as const
 
 export const THEME_OPTIONS: ThemeOption[] = [
   { value: 'light', label: '라이트' },
   { value: 'dark', label: '다크' },
-  { value: 'system', label: '시스템' },
 ]
 
 export const SETTINGS_STORAGE_KEY = 'gamyeon-settings'

--- a/src/featured/settings/constants.ts
+++ b/src/featured/settings/constants.ts
@@ -1,0 +1,26 @@
+import type { ThemeOption } from './types'
+
+export const SETTINGS_COPY = {
+  pageTitle: '설정',
+  pageDescription: '계정 정보와 서비스 환경을 관리하세요.',
+  sectionAccount: '계정',
+  sectionAccountDescription: '내 프로필 정보와 계정을 관리합니다.',
+  sectionGeneral: '일반',
+  sectionGeneralDescription: '화면과 알림 등 서비스 환경을 설정합니다.',
+  profileTitle: '프로필',
+  accountTitle: '계정 관리',
+  appearanceTitle: '화면',
+  notificationTitle: '알림',
+  localOnlyNotice: '알림 설정은 현재 기기에만 저장됩니다.',
+  nicknamePending: '닉네임 변경은 곧 제공될 예정입니다.',
+  themePending: '테마 변경은 곧 제공될 예정입니다.',
+  withdrawPendingToast: '회원 탈퇴 기능은 준비 중입니다.',
+} as const
+
+export const THEME_OPTIONS: ThemeOption[] = [
+  { value: 'light', label: '라이트' },
+  { value: 'dark', label: '다크' },
+  { value: 'system', label: '시스템' },
+]
+
+export const SETTINGS_STORAGE_KEY = 'gamyeon-settings'

--- a/src/featured/settings/hooks/useSettingsHydrated.ts
+++ b/src/featured/settings/hooks/useSettingsHydrated.ts
@@ -1,0 +1,26 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+import { useSettingsStore } from '../store'
+
+function subscribeToHydration(onStoreChange: () => void) {
+  const persist = useSettingsStore.persist
+
+  if (!persist) return () => undefined
+
+  const unsubscribeHydrate = persist.onHydrate(onStoreChange)
+  const unsubscribeFinishHydration = persist.onFinishHydration(onStoreChange)
+
+  return () => {
+    unsubscribeHydrate()
+    unsubscribeFinishHydration()
+  }
+}
+
+function getHydrationSnapshot() {
+  return useSettingsStore.persist?.hasHydrated() ?? false
+}
+
+export function useSettingsHydrated() {
+  return useSyncExternalStore(subscribeToHydration, getHydrationSnapshot, () => false)
+}

--- a/src/featured/settings/store.ts
+++ b/src/featured/settings/store.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import { SETTINGS_STORAGE_KEY } from './constants'
+import type { SettingsState } from './types'
+
+export const useSettingsStore = create<SettingsState>()(
+  persist(
+    (set) => ({
+      notificationEnabled: true,
+      setNotificationEnabled: (enabled: boolean) => set({ notificationEnabled: enabled }),
+    }),
+    {
+      name: SETTINGS_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+)

--- a/src/featured/settings/types.ts
+++ b/src/featured/settings/types.ts
@@ -6,7 +6,7 @@ export interface SettingsState extends NotificationSettings {
   setNotificationEnabled: (enabled: boolean) => void
 }
 
-export type ThemeValue = 'light' | 'dark' | 'system'
+export type ThemeValue = 'light' | 'dark'
 
 export interface ThemeOption {
   value: ThemeValue

--- a/src/featured/settings/types.ts
+++ b/src/featured/settings/types.ts
@@ -1,0 +1,14 @@
+export interface NotificationSettings {
+  notificationEnabled: boolean
+}
+
+export interface SettingsState extends NotificationSettings {
+  setNotificationEnabled: (enabled: boolean) => void
+}
+
+export type ThemeValue = 'light' | 'dark' | 'system'
+
+export interface ThemeOption {
+  value: ThemeValue
+  label: string
+}

--- a/src/shared/components/header.tsx
+++ b/src/shared/components/header.tsx
@@ -123,9 +123,11 @@ export function Header() {
                       대시보드
                     </Link>
                   </DropdownMenuItem>
-                  <DropdownMenuItem className="cursor-pointer gap-2">
-                    <Settings className="h-4 w-4" />
-                    설정
+                  <DropdownMenuItem asChild>
+                    <Link href="/settings" className="cursor-pointer gap-2">
+                      <Settings className="h-4 w-4" />
+                      설정
+                    </Link>
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem

--- a/src/shared/components/user-profile-button.tsx
+++ b/src/shared/components/user-profile-button.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { Avatar, AvatarFallback } from '@/shared/ui/avatar'
 import {
@@ -30,7 +31,10 @@ export function UserProfileButton() {
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
-        <button className="ring-primary/40 flex cursor-pointer items-center rounded-full transition outline-none hover:ring-2">
+        <button
+          aria-label="프로필 메뉴"
+          className="ring-primary/40 flex cursor-pointer items-center rounded-full transition outline-none hover:ring-2"
+        >
           <Avatar className="h-8 w-8 shrink-0">
             <AvatarFallback className="bg-primary/10 text-primary text-sm font-semibold">
               {initials}
@@ -47,9 +51,11 @@ export function UserProfileButton() {
           <LayoutDashboard className="h-4 w-4" />
           대시보드
         </DropdownMenuItem>
-        <DropdownMenuItem className="cursor-pointer gap-2">
-          <Settings className="h-4 w-4" />
-          설정
+        <DropdownMenuItem asChild>
+          <Link href="/settings" className="cursor-pointer gap-2">
+            <Settings className="h-4 w-4" />
+            설정
+          </Link>
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem

--- a/src/shared/lib/ThemeProvider.tsx
+++ b/src/shared/lib/ThemeProvider.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+import type { ComponentProps } from 'react'
+
+export function ThemeProvider({ children, ...props }: ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>
+}

--- a/src/shared/ui/sonner.tsx
+++ b/src/shared/ui/sonner.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { Toaster as Sonner, type ToasterProps } from 'sonner'
+
+export function Toaster(props: ToasterProps) {
+  const { theme = 'light' } = useTheme()
+
+  return <Sonner theme={theme as ToasterProps['theme']} {...props} />
+}

--- a/src/shared/ui/switch.tsx
+++ b/src/shared/ui/switch.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import * as React from 'react'
+import { Switch as SwitchPrimitive } from 'radix-ui'
+
+import { cn } from '@/lib/utils'
+
+function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        'peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 inline-flex h-[1.15rem] w-8 shrink-0 cursor-pointer items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          'bg-background pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0',
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }


### PR DESCRIPTION
## 변경 사항

- 설정페이지 ui 구현
    - 닉네임 변경 기능 구현 아직 x
    - 최초 진입 시 텍스트 형태로 프로필 보여주고, 버튼을 통해서 input 활성화하게 수정
- 라이트모드와 다크모드 구현을 위해 next-theme 사용
    - 최초 pull 받을 시에 npm i 실행 필요



close #107 
