### PR TITLE
fix: 재시작 면접 진행 상태 표시 개선

### DIFF
--- a/src/featured/interview/components/InterviewContainer.tsx
+++ b/src/featured/interview/components/InterviewContainer.tsx
@@ -14,16 +14,50 @@ export function InterviewContainer({ session }: InterviewPageProps) {
   const currentQuestionSetId =
     session.interviewQuestions[session.currentQuestion]?.questionSetId ?? null
 
+  const currentQuestionOrder =
+    session.interviewQuestions[session.currentQuestion]?.questionOrder ?? 0
+
   const handleStopRequest = () => session.setShowEndDialog(true)
+
+  const processBarQuestions = session.restartContext
+    ? session.restartContext.questions
+        .slice()
+        .sort((a, b) => a.questionOrder - b.questionOrder)
+        .map((q) => {
+          const answeredInCurrentSession = session.interviewQuestions
+            .slice(0, session.currentQuestion)
+            .some((iq) => iq.questionSetId === q.questionSetId)
+          const isCurrentQuestion =
+            session.interviewQuestions[session.currentQuestion]?.questionSetId === q.questionSetId
+          return {
+            questionSetId: q.questionSetId,
+            questionOrder: q.questionOrder,
+            status:
+              q.answered || answeredInCurrentSession
+                ? ('completed' as const)
+                : isCurrentQuestion && session.isActive
+                  ? ('active' as const)
+                  : ('pending' as const),
+          }
+        })
+    : session.interviewQuestions.map((q, i) => ({
+        questionSetId: q.questionSetId,
+        questionOrder: q.questionOrder,
+        status:
+          i < session.currentQuestion
+            ? ('completed' as const)
+            : i === session.currentQuestion && session.isActive
+              ? ('active' as const)
+              : ('pending' as const),
+      }))
 
   return (
     <div className="relative flex h-screen flex-col overflow-hidden bg-slate-950 text-white">
       <ProcessBar
         interviewTitle={session.interviewTitle}
-        currentQuestion={session.currentQuestion}
+        currentQuestionOrder={currentQuestionOrder}
         phase={session.phase}
-        isActive={session.isActive}
-        questions={session.interviewQuestions}
+        questions={processBarQuestions}
         onEndClick={handleStopRequest}
         onBackClick={handleStopRequest}
       />

--- a/src/featured/interview/components/screen/ProcessBar.tsx
+++ b/src/featured/interview/components/screen/ProcessBar.tsx
@@ -2,25 +2,29 @@
 
 import { Button } from '@/shared/ui/button'
 import { ArrowLeft, Power } from 'lucide-react'
-import type { Phase, InterviewQuestions } from '@/featured/interview/types'
+import type { Phase } from '@/featured/interview/types'
 import { TOTAL_QUESTION_COUNT } from '@/featured/interview/constants'
 import Image from 'next/image'
 
+interface ProcessBarQuestion {
+  questionSetId: number
+  questionOrder: number
+  status: 'completed' | 'active' | 'pending'
+}
+
 interface TopBarProps {
   interviewTitle: string
-  currentQuestion: number
+  currentQuestionOrder: number
   phase: Phase
-  isActive: boolean
-  questions: InterviewQuestions[]
+  questions: ProcessBarQuestion[]
   onEndClick: () => void
   onBackClick: () => void
 }
 
 export function ProcessBar({
   interviewTitle,
-  currentQuestion,
+  currentQuestionOrder,
   phase,
-  isActive,
   questions,
   onEndClick,
   onBackClick,
@@ -54,16 +58,16 @@ export function ProcessBar({
           <div
             key={q.questionSetId}
             className={`h-2 rounded-full transition-all duration-300 ${
-              q.questionOrder < (questions[currentQuestion]?.questionOrder ?? 0)
+              q.status === 'completed'
                 ? 'w-2 bg-green-500'
-                : q.questionOrder === questions[currentQuestion]?.questionOrder && isActive
+                : q.status === 'active'
                   ? 'bg-primary w-5'
                   : 'w-2 bg-white/20'
             }`}
           />
         ))}
         <span className="ml-2 text-xs text-white/50">
-          {questions[currentQuestion]?.questionOrder} / {TOTAL_QUESTION_COUNT}
+          {currentQuestionOrder} / {TOTAL_QUESTION_COUNT}
         </span>
       </div>
 

--- a/src/featured/interview/components/screen/QuestionBanner.tsx
+++ b/src/featured/interview/components/screen/QuestionBanner.tsx
@@ -37,7 +37,7 @@ export function QuestionBanner({
         >
           <div className="flex w-full max-w-2xl items-start gap-3 rounded-2xl border border-white/10 bg-slate-800/90 px-5 py-4 shadow-2xl backdrop-blur-md">
             <span className="bg-primary mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-bold text-white">
-              {currentQuestion + 1}
+              {questions[currentQuestion]?.questionOrder ?? currentQuestion + 1}
             </span>
             <p className="text-sm leading-relaxed font-medium text-white/95">
               {!questionRevealed ? (

--- a/src/featured/interview/hooks/useSetupModal.ts
+++ b/src/featured/interview/hooks/useSetupModal.ts
@@ -126,7 +126,14 @@ export function useSetupModal({ session, isRestart }: UseSetupModalParams) {
       interviewId: session.interviewId,
       questions: activeQuestions ?? [],
     })
-  }, [cameraHandler, session, isRestart, titleStep.title, activeQuestions])
+  }, [
+    cameraHandler.cameraStream,
+    cameraHandler.basePose,
+    session,
+    isRestart,
+    titleStep.title,
+    activeQuestions,
+  ])
 
   const isStartDisabled =
     !allDone ||


### PR DESCRIPTION
## 변경 사항

- ProcessBar - 재시작 시 전체 질문 진행 상태 표시
기존: 미답변 질문만 표시 (재시작 시 전체 7개 중 남은 것만 보임)
변경: restartContext 있을 때 전체 7개 질문을 항상 표시하고, 이전 세션에서 답변 완료한 질문은 초록색, 이번 세션에서 완료한 질문도 초록색, 현재 진행 중인 질문은 형광 초록색(active), 미답변은 회색으로 구분

- QuestionBanner - 재시작 시 실제 질문 번호 표시
기존: currentQuestion 인덱스 기준으로 1부터 표시 (재시작 시 4번 질문인데 1로 표시됨)
변경: questions[currentQuestion].questionOrder 사용하여 실제 질문 순서 번호 표시

close #114 
